### PR TITLE
Fix decimal precision

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def number_with_precision(number, options = {})
+    super(number, { precision: 3 }.merge(options))
+  end
+
   def navigation_link_to(name, path, icon, exact = false)
     default_classes = "group flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-light-blue hover:bg-blue-700 hover:text-white"
     active_classes = "bg-blue-700 text-white"
@@ -28,8 +32,6 @@ module ApplicationHelper
   end
 
   def current_or_nested_page?(path, exact = false)
-    Rails.logger.debug "current_page?(#{path}) = #{current_page?(path)} | exact = #{exact} | request.path.start_with?(#{path}) = #{request.path.start_with?(path)}"
-    Rails.logger.debug exact ? current_page?(path) : current_page?(path) || request.path.start_with?(path)
     exact ? current_page?(path) : current_page?(path) || request.path.start_with?(path)
   end
 

--- a/app/helpers/factory/making_orders_helper.rb
+++ b/app/helpers/factory/making_orders_helper.rb
@@ -4,6 +4,6 @@ module Factory::MakingOrdersHelper
   end
 
   def formula_item_weight_per_round(item_proportion, weight)
-    number_with_precision(item_proportion / 100.0 * weight, precision: 3)
+    number_with_precision(item_proportion / 100.0 * weight)
   end
 end

--- a/app/views/factory/making_orders/_making_order.html.erb
+++ b/app/views/factory/making_orders/_making_order.html.erb
@@ -21,7 +21,7 @@
 
   <p class="my-5">
     <strong class="block font-medium mb-1">Mixer capacity:</strong>
-    <%= making_order.mixer_capacity %>
+    <%= number_with_precision making_order.mixer_capacity, precision: 1 %>
   </p>
 
   <p class="my-5">

--- a/app/views/factory/making_orders/show.html.erb
+++ b/app/views/factory/making_orders/show.html.erb
@@ -25,9 +25,9 @@
             end
           },
         },
-        { label: MakingOrder.human_attribute_name(:weight_per_round), value: "#{@making_order.weight_per_round} kg" },
+        { label: MakingOrder.human_attribute_name(:weight_per_round), value: "#{number_with_precision @making_order.weight_per_round} kg" },
         { label: MakingOrder.human_attribute_name(:rounds_count), value: @making_order.rounds_count },
-        { label: MakingOrder.human_attribute_name(:mixer_capacity), value: @making_order.mixer_capacity },
+        { label: MakingOrder.human_attribute_name(:mixer_capacity), value: number_with_precision(@making_order.mixer_capacity, precision: 1) },
         { label: MakingOrder.human_attribute_name(:comments), value: @making_order.comments },
         { label: MakingOrder.human_attribute_name(:state), value: t("#{@making_order.state}", scope: [:activerecord, :attributes, :making_order, :state_values]) },
         { label: MakingOrder.human_attribute_name(:created_at), value: l(@making_order.created_at, format: :long) },


### PR DESCRIPTION
## Summary

This pull request includes several changes to improve the precision formatting of numerical values across different parts of the application. The most important changes include adding a helper method for number precision and updating views to use the new precision formatting.

### Helper Methods:
* Added `number_with_precision` method in `app/helpers/application_helper.rb` to format numbers with a default precision of 3.
* Updated `formula_item_weight_per_round` method in `app/helpers/factory/making_orders_helper.rb` to use the new `number_with_precision` method without specifying precision.

### Views:
* Updated `app/views/factory/making_orders/_making_order.html.erb` to use `number_with_precision` for `mixer_capacity` with precision of 1.
* Updated `app/views/factory/making_orders/show.html.erb` to use `number_with_precision` for `weight_per_round` and `mixer_capacity`.

<!-- ## Deployment Notes -->

<!-- Provide any specific deployment notes or steps that need to be taken post-merge. -->
