### PR TITLE
Fix print view

### DIFF
--- a/app/assets/stylesheets/print.css
+++ b/app/assets/stylesheets/print.css
@@ -14,13 +14,14 @@
 @media print {
   html {
     font-family: Tahoma, Helvetica, sans-serif;
-    font-size: 8px;
+    font-size: 16px;
     display: block;
     transition: 0s;
   }
 
   body {
     background-color: #fff;
+    padding: 4px;
   }
 
   .web {

--- a/app/views/office/discounts/edit.html.erb
+++ b/app/views/office/discounts/edit.html.erb
@@ -11,7 +11,7 @@
       <dd class="mt-1 flex flex-1">
         <%= form_with(model: [:office, @discount], class: "contents flex-1") do |form| %>
           <div class="flex justify-between gap-x-6 sm:mt-0 sm:flex-auto">
-            <%= form.text_field :percentage, class: "block rounded-md bg-black/5 px-3 py-1.5 text-base text-black outline-1 -outline-offset-1 outline-black/10 placeholder:text-gray-500 focus:outline-2 focus:-outline-offset-2 focus:outline-blue-500 sm:text-sm/6 #{@discount.errors[:percentage].present? ? 'border-red-500' : 'border-gray-300'}" %>
+            <%= form.text_field :percentage, autofocus: true, class: "block rounded-md bg-black/5 px-3 py-1.5 text-base text-black outline-1 -outline-offset-1 outline-black/10 placeholder:text-gray-500 focus:outline-2 focus:-outline-offset-2 focus:outline-blue-500 sm:text-sm/6 #{@discount.errors[:percentage].present? ? 'border-red-500' : 'border-gray-300'}" %>
             <%= form.submit t("actions.save"), data: { turbo_submits_with: t("messages.saving") }, class: "btn-primary" %>
           </div>
         <% end %>


### PR DESCRIPTION
## Summary

This pull request includes updates to the print stylesheet and the discount edit form view. The most important changes are:

Styling updates:

* [`app/assets/stylesheets/print.css`](diffhunk://#diff-19da39f342945b70560a869144f48fcb27e0c804dfd0b3f08ddc685e1db328a8L17-R24): Increased the font size from 8px to 16px and added padding to the body to improve print readability.

Form enhancements:

* [`app/views/office/discounts/edit.html.erb`](diffhunk://#diff-9f0467a97b321531e9d754cf756911af4c5306a6ee1839833242bef3df5c5d45L14-R14): Added the `autofocus` attribute to the percentage input field to improve user experience by focusing on the input field when the page loads.

<!-- ## Deployment Notes -->

<!-- Provide any specific deployment notes or steps that need to be taken post-merge. -->
