### PR TITLE
Products: purchased and manufactured

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem "thruster", require: false
 gem "kaminari"
 gem "ransack"
 gem "chartkick"
+gem "maintenance_tasks"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
+    csv (3.3.2)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -123,6 +124,12 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86-linux-gnu)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -145,6 +152,8 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    job-iteration (1.9.0)
+      activejob (>= 5.2)
     json (2.10.2)
     kamal (2.5.3)
       activesupport (>= 7.0)
@@ -180,6 +189,14 @@ GEM
       net-imap
       net-pop
       net-smtp
+    maintenance_tasks (2.11.0)
+      actionpack (>= 7.0)
+      activejob (>= 7.0)
+      activerecord (>= 7.0)
+      csv
+      job-iteration (>= 1.3.6)
+      railties (>= 7.0)
+      zeitwerk (>= 2.6.2)
     marcel (1.0.4)
     matrix (0.4.2)
     mini_mime (1.1.5)
@@ -429,6 +446,7 @@ DEPENDENCIES
   jbuilder
   kamal
   kaminari
+  maintenance_tasks
   pg (~> 1.5)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/factory/products_controller.rb
+++ b/app/controllers/factory/products_controller.rb
@@ -6,7 +6,7 @@ module Factory
 
     # GET /products or /products.json
     def index
-      @q = Product.includes(:formula).ransack(params[:q] || default_sort)
+      @q = Product.manufactured_products.includes(:formula).ransack(params[:q] || default_sort)
       @products = @q.result.page(params[:page])
     end
 
@@ -16,7 +16,7 @@ module Factory
 
     # GET /products/new
     def new
-      @product = Product.new
+      @product = Product.new(productable: ManufacturedProduct.new)
     end
 
     # GET /products/1/edit
@@ -25,10 +25,13 @@ module Factory
 
     # POST /products or /products.json
     def create
-      @product = Product.new(product_params)
+      @product = Product.new(
+        **product_params,
+        productable: ManufacturedProduct.new(manufactured_product_params),
+      )
 
       respond_to do |format|
-        if @product.save
+        if @product.save(context: :factory)
           format.html { redirect_to factory_product_path(@product), notice: "Product was successfully created." }
           format.json { render :show, status: :created, location: @product }
         else
@@ -40,8 +43,11 @@ module Factory
 
     # PATCH/PUT /products/1 or /products/1.json
     def update
+      @product.assign_attributes(product_params)
+      @product.productable.assign_attributes(manufactured_product_params)
+
       respond_to do |format|
-        if @product.update(product_params)
+        if @product.save(context: :factory)
           format.html { redirect_to factory_product_path(@product), notice: "Product was successfully updated." }
           format.json { render :show, status: :ok, location: @product }
         else
@@ -67,7 +73,19 @@ module Factory
       end
 
       def product_params
-        params.expect(product: [ :name, :price, :formula_id, :shape, :size, :weight, :pressure ])
+        params.expect(product: [ :description, :min_stock, :max_stock, :current_stock ])
+      end
+
+      def manufactured_product_params
+        params
+          .require(:product)
+          .expect(productable_attributes: [
+            :formula_id,
+            :pressure,
+            :shape,
+            :size,
+            :weight,
+          ])
       end
 
       def default_sort

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,6 +41,7 @@ module ApplicationHelper
       [
         { name: t("navigation.dashboard"), path: office_root_path, icon: "home", exact: true },
         { name: t("titles.client.index"), path: office_clients_path, icon: "building-storefront" },
+        { name: t("titles.product.index"), path: office_products_path, icon: "cube" },
         { name: t("titles.setting.index"), path: office_settings_path, icon: "cog-8-tooth" },
       ]
     when /^\/sales/

--- a/app/models/concerns/product/productables.rb
+++ b/app/models/concerns/product/productables.rb
@@ -1,0 +1,11 @@
+module Product::Productables
+  extend ActiveSupport::Concern
+
+  included do
+    PRODUCTABLE_TYPES = %w[ ManufacturedProduct PurchasedProduct ]
+
+    delegated_type :productable, types: PRODUCTABLE_TYPES, dependent: :destroy
+    validates_associated :productable
+    accepts_nested_attributes_for :productable
+  end
+end

--- a/app/models/concerns/productable.rb
+++ b/app/models/concerns/productable.rb
@@ -3,7 +3,6 @@ module Productable
 
   included do
     has_one :product, as: :productable, touch: true, autosave: true
-    validates_associated :product
     default_scope { includes(:product) }
 
     def name

--- a/app/models/concerns/productable.rb
+++ b/app/models/concerns/productable.rb
@@ -1,0 +1,13 @@
+module Productable
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :product, as: :productable, touch: true, autosave: true
+    validates_associated :product
+    default_scope { includes(:product) }
+
+    def name
+      raise NotImplementedError
+    end
+  end
+end

--- a/app/models/making_order.rb
+++ b/app/models/making_order.rb
@@ -41,11 +41,12 @@ class MakingOrder < ApplicationRecord
     end
 
     def set_total_weight
-      self.total_weight = self.making_order_items.reject(&:marked_for_destruction?).sum { |item| item.product.weight * (item.quantity || 0) }
+      self.total_weight = self.making_order_items.reject(&:marked_for_destruction?).sum { |item| item.product.productable.weight * (item.quantity || 0) }
     end
 
     def set_making_order_formula
-      self.build_making_order_formula(formula_id: making_order_items.first.product.formula_id)
+      productable = making_order_items.first.product.productable
+      self.build_making_order_formula(formula_id: productable.formula_id)
     end
 
     def set_formula_dirty
@@ -56,7 +57,7 @@ class MakingOrder < ApplicationRecord
       self.making_order_items.each do |item|
         next unless item.changed?
 
-        unless item.product.formula_id == self.making_order_formula.formula_id
+        unless item.product.productable.formula_id == self.making_order_formula.formula_id
           errors.add(
             :base,
             I18n.t(:products_formula_is_different, scope: [ :activerecord, :errors, :models, :making_order ])

--- a/app/models/making_order_item.rb
+++ b/app/models/making_order_item.rb
@@ -9,10 +9,10 @@ class MakingOrderItem < ApplicationRecord
   private
     def prepare_product_fields
       self.product_name = product.name
-      self.product_shape = product.shape
-      self.product_pressure = product.pressure
-      self.product_size = product.size
-      self.product_weight = product.weight
+      self.product_shape = product.productable.shape
+      self.product_pressure = product.productable.pressure
+      self.product_size = product.productable.size
+      self.product_weight = product.productable.weight
     end
 end
 

--- a/app/models/manufactured_product.rb
+++ b/app/models/manufactured_product.rb
@@ -1,0 +1,41 @@
+class ManufacturedProduct < ApplicationRecord
+  include Productable
+
+  belongs_to :formula
+  has_many :formula_elements, through: :formula
+
+  delegate :name, to: :formula, prefix: true, allow_nil: true
+
+  validates :formula, presence: true
+  validates :pressure, :shape, :size, :weight, presence: true
+  validates :weight, numericality: { greater_than_or_equal_to: 0 }
+
+  def name
+    if shape.present? && size.present? && formula_name.present? && pressure.present?
+      combined_name = [ shape, size, formula_name, pressure ].join
+      combined_name.gsub(" ", "")
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: manufactured_products
+#
+#  id         :bigint           not null, primary key
+#  pressure   :string
+#  shape      :string
+#  size       :string
+#  weight     :decimal(, )
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  formula_id :bigint
+#
+# Indexes
+#
+#  index_manufactured_products_on_formula_id  (formula_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (formula_id => formulas.id)
+#

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -21,7 +21,7 @@ class Product < ApplicationRecord
 
   private
     def set_name
-      self.name = productable.name if productable&.name&.present?
+      self.name = productable.name unless productable&.name.nil?
     end
 
     def name_is_unique

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,33 +1,27 @@
 class Product < ApplicationRecord
-  belongs_to :formula, dependent: :destroy
-  has_many :formula_elements, through: :formula
+  include Productables
+
+  belongs_to :formula, optional: true # This is optional until manufactured product details refactor is complete
   has_many :making_order_items, dependent: :nullify
 
-  delegate :name, to: :formula, prefix: true, allow_nil: true
-
-  scope :by_formula, ->(formula_id) { where(formula_id: formula_id) }
-
-  validates :name, :shape, :size, :pressure, :price, :weight, presence: true
-  validates :price, numericality: { greater_than_or_equal_to: 0 }, unless: -> { name.blank? }
-  validates :weight, numericality: { greater_than_or_equal_to: 0 }, unless: -> { name.blank? }
-  validate :name_is_unique, unless: -> { name.blank? }
-
   before_validation :set_name
+  validates :name, presence: true
+  validate :name_is_unique, unless: -> { name.blank? }
+  validates :current_stock, :max_stock, :min_stock, numericality: { greater_than_or_equal_to: 0 }
+  validates :price, presence: true, on: [ :office ]
+  validates :price, numericality: { greater_than_or_equal_to: 0 }, if: -> { price.present? }
 
   def self.ransackable_attributes(auth_object = nil)
-    %w[id name pressure price shape size weight]
+    %w[id name]
   end
 
   def self.ransackable_associations(auth_object = nil)
-    %w[formula]
+    %w[formula productable]
   end
 
   private
     def set_name
-      if shape.present? && size.present? && formula_name.present? && pressure.present?
-        combined_name = [ shape, size, formula_name, pressure ].join
-        self.name = combined_name.gsub(" ", "")
-      end
+      self.name = productable.name if productable&.name&.present?
     end
 
     def name_is_unique
@@ -42,14 +36,20 @@ end
 #
 # Table name: products
 #
-#  id         :bigint           not null, primary key
-#  name       :string
-#  pressure   :string
-#  price      :decimal(, )
-#  shape      :string
-#  size       :string
-#  weight     :decimal(, )
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  formula_id :integer
+#  id               :bigint           not null, primary key
+#  current_stock    :integer          default(0), not null
+#  description      :text
+#  max_stock        :integer          default(0), not null
+#  min_stock        :integer          default(0), not null
+#  name             :string
+#  pressure         :string
+#  price            :decimal(, )
+#  productable_type :string
+#  shape            :string
+#  size             :string
+#  weight           :decimal(, )
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  formula_id       :integer
+#  productable_id   :integer
 #

--- a/app/models/purchased_product.rb
+++ b/app/models/purchased_product.rb
@@ -1,0 +1,17 @@
+class PurchasedProduct < ApplicationRecord
+  include Productable
+
+  def name
+    nil
+  end
+end
+
+# == Schema Information
+#
+# Table name: purchased_products
+#
+#  id         :bigint           not null, primary key
+#  base_cost  :decimal(, )
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#

--- a/app/tasks/maintenance/set_product_price_to_0_when_null_task.rb
+++ b/app/tasks/maintenance/set_product_price_to_0_when_null_task.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class SetProductPriceTo0WhenNullTask < MaintenanceTasks::Task
+    def collection
+      Product.all
+    end
+
+    def process(product)
+      return if product.price.present?
+
+      product.update_column(:price, 0)
+    end
+
+    def count
+      Product.count
+    end
+  end
+end

--- a/app/tasks/maintenance/split_product_into_polymorphic_associations_task.rb
+++ b/app/tasks/maintenance/split_product_into_polymorphic_associations_task.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class SplitProductIntoPolymorphicAssociationsTask < MaintenanceTasks::Task
+    def collection
+      Product.all
+    end
+
+    def process(product)
+      return if product.productable.present?
+
+      product.productable = ManufacturedProduct.build(
+        formula: product.formula,
+        pressure: product.pressure,
+        shape: product.shape,
+        size: product.size,
+        weight: product.weight
+      )
+      product.save!
+    end
+
+    def count
+      Product.count
+    end
+  end
+end

--- a/app/views/common/lists/_description.html.erb
+++ b/app/views/common/lists/_description.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (items:) -%>
 
-<dl class="divide-y divide-light-gray">
+<dl class="divide-y divide-light-gray border-b border-light-gray">
   <% items.each do |item| %>
     <div class="px-4 py-6 grid grid-cols-2 md:grid-cols-3 sm:gap-4 sm:px-0">
       <dt class="text-sm font-medium leading-6 text-gray-100"><%= item[:label] %></dt>

--- a/app/views/factory/products/_form.html.erb
+++ b/app/views/factory/products/_form.html.erb
@@ -4,51 +4,89 @@
   <%= render "common/error_messages", model: product %>
   <%= render "common/forms/simple" do %>
     <div class="col-span-6 md:col-span-3 grid grid-cols-1 gap-x-6 gap-y-8">
-
-      <%= render("common/components/dropdown",
-        placeholder: t("helpers.select.prompt", model: Formula.model_name.human),
-        input_name: "product[formula_id]",
-        input_value: product.formula_id,
-        search_value: product&.formula_name,
-        input_classes: "text-xs #{'ring-red' if product.errors.any?}",
-        url: factory_formulas_path,
-      ) %>
-
       <div>
-        <%= form.label :shape, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <%= form.label :description, class: "block text-sm font-medium leading-6 text-gray-900" %>
         <div class="mt-2">
-          <%= form.text_field :shape, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+          <%= form.textarea :description, rows: 4, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
         </div>
       </div>
 
       <div>
-        <%= form.label :size, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <%= form.label :min_stock, class: "block text-sm font-medium leading-6 text-gray-900" %>
         <div class="mt-2">
-          <%= form.text_field :size, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+          <%= form.number_field :min_stock, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
         </div>
       </div>
 
       <div>
-        <%= form.label :weight, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <%= form.label :max_stock, class: "block text-sm font-medium leading-6 text-gray-900" %>
         <div class="mt-2">
-          <%= form.number_field :weight, min: 0, step: 0.01, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+          <%= form.number_field :max_stock, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
         </div>
       </div>
 
       <div>
-        <%= form.label :pressure, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <%= form.label :current_stock, class: "block text-sm font-medium leading-6 text-gray-900" %>
         <div class="mt-2">
-          <%= form.text_field :pressure, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+          <%= form.number_field :current_stock, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
         </div>
       </div>
+    </div>
 
-      <div>
-        <%= form.label :price, min: 0, step: 0.01, class: "block text-sm font-medium leading-6 text-gray-900" %>
-        <div class="mt-2">
-          <%= form.number_field :price, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+    <div class="col-span-6 md:col-span-3 grid grid-cols-1 gap-x-6 gap-y-8">
+      <%= form.fields_for :productable, @product.productable do |productable_fields| %>
+        <div>
+          <%= productable_fields.label :formula_id, class: "block text-sm font-medium leading-6 text-gray-900" %>
+          <div class="mt-2">
+            <%= render("common/components/dropdown",
+              placeholder: t("helpers.select.prompt", model: Formula.model_name.human),
+              input_name: "product[formula_id]",
+              input_value: product.productable.formula_id,
+              search_value: product&.productable&.formula_name,
+              input_classes: "text-xs #{'ring-red' if product.errors.any?}",
+              url: factory_formulas_path,
+            ) %>
+          </div>
         </div>
-      </div>
+        <div>
+          <%= productable_fields.label :shape, class: "block text-sm font-medium leading-6 text-gray-900" %>
+          <div class="mt-2">
+            <%= productable_fields.text_field :shape, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+          </div>
+        </div>
 
+        <div>
+          <%= productable_fields.label :size, class: "block text-sm font-medium leading-6 text-gray-900" %>
+          <div class="mt-2">
+            <%= productable_fields.text_field :size, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+          </div>
+        </div>
+
+        <div>
+          <%= productable_fields.label :weight, class: "block text-sm font-medium leading-6 text-gray-900" %>
+          <div class="mt-2">
+            <%= productable_fields.number_field :weight, min: 0, step: 0.01, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+          </div>
+        </div>
+
+        <div>
+          <%= productable_fields.label :pressure, class: "block text-sm font-medium leading-6 text-gray-900" %>
+          <div class="mt-2">
+            <%= productable_fields.text_field :pressure, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+          </div>
+        </div>
+
+        <!-- Product price
+        <div>
+          <%= form.label :price, min: 0, step: 0.01, class: "block text-sm font-medium leading-6 text-gray-900" %>
+          <div class="mt-2">
+            <%= form.number_field :price, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+          </div>
+        </div>
+        -->
+      <% end %>
+    </div>
+    <div class="col-span-6 md:col-span-3 grid grid-cols-1 gap-x-6 gap-y-8">
       <div>
         <%= form.submit t("actions.save"), class: "btn-primary" %>
       </div>

--- a/app/views/factory/products/_form.html.erb
+++ b/app/views/factory/products/_form.html.erb
@@ -75,15 +75,6 @@
             <%= productable_fields.text_field :pressure, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
           </div>
         </div>
-
-        <!-- Product price
-        <div>
-          <%= form.label :price, min: 0, step: 0.01, class: "block text-sm font-medium leading-6 text-gray-900" %>
-          <div class="mt-2">
-            <%= form.number_field :price, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
-          </div>
-        </div>
-        -->
       <% end %>
     </div>
     <div class="col-span-6 md:col-span-3 grid grid-cols-1 gap-x-6 gap-y-8">

--- a/app/views/factory/products/_product.json.jbuilder
+++ b/app/views/factory/products/_product.json.jbuilder
@@ -1,2 +1,11 @@
-json.extract! product, :id, :name, :formula_id, :shape, :size, :weight, :pressure
+json.extract! product, :id, :name, :min_stock, :max_stock, :current_stock, :description
+
+json.manufactured_product do
+  json.id product.manufactured_product.id
+  json.formula_id product.manufactured_product.formula_id
+  json.shape product.manufactured_product.shape
+  json.size product.manufactured_product.size
+  json.weight product.manufactured_product.weight
+  json.pressure product.manufactured_product.pressure
+end
 json.url factory_product_url(product, format: :json)

--- a/app/views/factory/products/index.html.erb
+++ b/app/views/factory/products/index.html.erb
@@ -53,7 +53,7 @@
                 <%= sort_link(@q, :name, Product.human_attribute_name(:name), class: "flex justify-center", data: { turbo_action: "advance"}) %>
               </th>
               <th scope="col" class="px-2 md:px-4 py-3 text-sm font-semibold text-gray-900 group">
-                <%= sort_link(@q, :formula_name, Product.human_attribute_name(:formula), class: "flex justify-center", data: { turbo_action: "advance"}) %>
+                <%= sort_link(@q, :manufactured_product_formula_name, ManufacturedProduct.human_attribute_name(:formula), class: "flex justify-center", data: { turbo_action: "advance"}) %>
               </th>
               <th scope="col" class="px-2 md:px-4 py-3 text-sm font-semibold text-gray-900 group">
                 <%= sort_link(@q, :price, Product.human_attribute_name(:price), class: "flex justify-center", data: { turbo_action: "advance"}) %>
@@ -73,7 +73,7 @@
                   <%= link_to product.name, factory_product_path(product), class: "flex justify-center", data: { turbo_frame: "_top" } %>
                 </td>
                 <td class="whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-500 text-center">
-                  <%= link_to product.formula_name, factory_product_path(product), class: "flex justify-center", data: { turbo_frame: "_top" } %>
+                  <%= link_to product.manufactured_product.formula_name, factory_product_path(product), class: "flex justify-center", data: { turbo_frame: "_top" } %>
                 </td>
                 <td class="whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-500 text-center">
                   <%= number_to_currency product.price %>

--- a/app/views/factory/products/show.html.erb
+++ b/app/views/factory/products/show.html.erb
@@ -17,21 +17,33 @@
       items: [
         { label: Product.human_attribute_name(:id), value: @product.id },
         { label: Product.human_attribute_name(:name), value: @product.name },
-        { label: Product.human_attribute_name(:shape), value: @product.shape },
+        { label: Product.human_attribute_name(:description), value: @product.description },
+        { label: Product.human_attribute_name(:min_stock), value: @product.min_stock },
+        { label: Product.human_attribute_name(:max_stock), value: @product.max_stock },
+        { label: Product.human_attribute_name(:current_stock), value: @product.current_stock },
+      ]
+    ) %>
+  </div>
+  <div>
+    <%= render(
+      "common/lists/description",
+      items: [
         {
-          label: Product.human_attribute_name(:formula),
+          label: ManufacturedProduct.human_attribute_name(:formula),
           block: -> {
-            link_to(factory_formula_path(@product.formula), class: "font-semibold") do
-              "#{@product.formula_name} (##{@product.formula_id})"
+            link_to(factory_formula_path(@product.manufactured_product.formula), class: "font-semibold") do
+              "#{@product.manufactured_product.formula_name} (##{@product.manufactured_product.formula_id})"
             end
           },
         },
-        { label: Product.human_attribute_name(:size), value: @product.size },
-        { label: Product.human_attribute_name(:weight), value: number_with_precision(@product.weight) },
-        { label: Product.human_attribute_name(:pressure), value: @product.pressure },
-        { label: Product.human_attribute_name(:price), value: number_to_currency(@product.price) },
+        { label: ManufacturedProduct.human_attribute_name(:shape), value: @product.manufactured_product.shape },
+        { label: ManufacturedProduct.human_attribute_name(:size), value: @product.manufactured_product.size },
+        { label: ManufacturedProduct.human_attribute_name(:weight), value: number_with_precision(@product.manufactured_product.weight) },
+        { label: ManufacturedProduct.human_attribute_name(:pressure), value: @product.manufactured_product.pressure },
       ]
     ) %>
+  </div>
+  <div>
     <div class="border-b border-light-gray-500 bg-white py-6 mb-6">
       <h3 class="text-base font-semibold text-gray-900">Historial de cambios</h3>
     </div>

--- a/app/views/office/products/_form.html.erb
+++ b/app/views/office/products/_form.html.erb
@@ -1,0 +1,61 @@
+<%# locals: (product:)  %>
+
+<%= form_with(model: [:office, product], class: "contents") do |form| %>
+  <%= render "common/error_messages", model: product %>
+  <%= render "common/forms/simple" do %>
+    <div class="col-span-6 md:col-span-3 grid grid-cols-1 gap-x-6 gap-y-8">
+      <div>
+        <%= form.label :name, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= form.text_field :name, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+        </div>
+      </div>
+
+      <div>
+        <%= form.label :description, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= form.textarea :description, rows: 4, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+        </div>
+      </div>
+
+      <div>
+        <%= form.label :min_stock, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= form.number_field :min_stock, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+        </div>
+      </div>
+
+      <div>
+        <%= form.label :max_stock, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= form.number_field :max_stock, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+        </div>
+      </div>
+
+      <div>
+        <%= form.label :current_stock, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= form.number_field :current_stock, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-span-6 md:col-span-3 grid grid-cols-1 gap-x-6 gap-y-8">
+      <%= form.fields_for :productable, product.productable do |productable_fields| %>
+        <div>
+          <%= form.label :price, class: "block text-sm font-medium leading-6 text-gray-900" %>
+          <div class="mt-2">
+            <%= form.number_field :price, min: 0, step: 0.01, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+          </div>
+        </div>
+
+        <%= render "office/products/productables/#{product.productable_name}_fields", form: productable_fields %>
+      <% end %>
+    </div>
+    <div class="col-span-6 md:col-span-3 grid grid-cols-1 gap-x-6 gap-y-8">
+      <div>
+        <%= form.submit t("actions.save"), class: "btn-primary" %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/office/products/_product.json.jbuilder
+++ b/app/views/office/products/_product.json.jbuilder
@@ -1,0 +1,3 @@
+json.extract! product, :id, :name, :min_stock, :max_stock, :current_stock, :description, :productable_id, :productable_type
+
+json.url office_product_url(product, format: :json)

--- a/app/views/office/products/edit.html.erb
+++ b/app/views/office/products/edit.html.erb
@@ -1,0 +1,25 @@
+<%= render(
+  "common/headings/page",
+  breadcrumbs: [
+    { title: t("navigation.dashboard"), path: office_root_path },
+    { title: t("titles.product.index"), path: office_products_path },
+    { title: @product.name, path: office_product_path(@product) },
+    { title: t("navigation.edit"), path: edit_office_product_path(@product) },
+  ],
+  title: @product.name,
+  options_dropdown: [
+    ->(classes, index:) do
+      button_to(
+        t(:archive, scope: [:actions]),
+        office_product_path(@product),
+        method: :delete,
+        data: { turbo_confirm: t("messages.are_you_sure") },
+        class: "#{classes} text-red-500",
+      )
+    end
+  ],
+) %>
+
+<div class="w-full">
+  <%= render "form", product: @product %>
+</div>

--- a/app/views/office/products/index.html.erb
+++ b/app/views/office/products/index.html.erb
@@ -1,0 +1,92 @@
+<%= render "common/headings/page",
+  title: t("titles.product.index"),
+  actions: [
+    { label: t("navigation.new"), path: new_office_product_path, method: :get },
+  ],
+  breadcrumbs: [
+    { title: t("navigation.dashboard"), path: office_root_path },
+    { title: t("titles.product.index"), path: office_products_path },
+  ] %>
+
+<div class="w-full">
+  <div class="mt-8 flow-root">
+    <div class="flex flex-1">
+      <%= search_form_for(
+        @q,
+        url: office_products_path,
+        method: :get,
+        data: {
+          turbo_frame: "products_table",
+          turbo_action: "advance",
+          controller: "common--submit-debounce",
+          action: "input->common--submit-debounce#submit",
+        },
+        class: "w-full max-w-lg lg:max-w-xs",
+      ) do |f| %>
+        <%= f.label :id_or_name_cont, t("placeholders.search_by.name"), class: "sr-only" %>
+        <div class="relative text-gray-300 focus-within:text-gray">
+          <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+            <svg class="size-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+              <path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11ZM2 9a7 7 0 1 1 12.452 4.391l3.328 3.329a.75.75 0 1 1-1.06 1.06l-3.329-3.328A7 7 0 0 1 2 9Z" clip-rule="evenodd" />
+            </svg>
+          </div>
+          <%= f.search_field(
+            :id_or_name_cont,
+            autofocus: true,
+            autocomplete: "off",
+            class: "block w-full rounded-md border-0 ring-0 ring-offset-1 ring-offset-gray bg-white py-1.5 pl-10 pr-3 text-gray-900 focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-blue sm:text-sm/6",
+            placeholder: t("placeholders.search_by.name"),
+          ) %>
+        </div>
+      <% end %>
+    </div>
+
+    <%= turbo_frame_tag "products_table" do %>
+      <div class="inline-block min-w-full py-2 align-middle">
+        <table id="formulas" class="min-w-full divide-y divide-light-gray-900">
+          <thead>
+            <tr>
+              <th scope="col" class="py-3 text-sm font-semibold text-gray-900 group">
+                <%= sort_link(@q, :id, Product.human_attribute_name(:id), class: "flex justify-center", data: { turbo_action: "advance"}) %>
+              </th>
+              <th scope="col" class="px-2 md:px-4 py-3 text-sm font-semibold text-gray-900 group">
+                <%= sort_link(@q, :name, Product.human_attribute_name(:name), class: "flex justify-center", data: { turbo_action: "advance"}) %>
+              </th>
+              <th scope="col" class="px-2 md:px-4 py-3 text-sm font-semibold text-gray-900 group">
+                <%= sort_link(@q, :product_current_stock, Product.human_attribute_name(:current_stock), class: "flex justify-center", data: { turbo_action: "advance"}) %>
+              </th>
+              <th scope="col" class="px-2 md:px-4 py-3 text-sm font-semibold text-gray-900 group">
+                <%= sort_link(@q, :price, Product.human_attribute_name(:price), class: "flex justify-center", data: { turbo_action: "advance"}) %>
+              </th>
+              <th scope="col" class="px-2 md:px-4 py-3 text-sm font-semibold text-gray-900 group">
+                <%= sort_link(@q, :created_at, Product.human_attribute_name(:created_at), class: "flex justify-center", data: { turbo_action: "advance"}) %>
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-light-gray">
+            <% @products.each do |product| %>
+              <tr class="hover:bg-light-gray-50">
+                <td class="whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-900">
+                  <%= link_to product.id, office_product_path(product), class: "flex justify-center", data: { turbo_frame: "_top" } %>
+                </td>
+                <td class="whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-500 text-center">
+                  <%= link_to product.name, office_product_path(product), class: "flex justify-center", data: { turbo_frame: "_top" } %>
+                </td>
+                <td class="whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-500 text-center">
+                  <%= link_to product.current_stock, office_product_path(product), class: "flex justify-center", data: { turbo_frame: "_top" } %>
+                </td>
+                <td class="whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-500 text-center">
+                  <%= number_to_currency product.price %>
+                </td>
+                <td class="whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-500 text-center">
+                  <%=l product.created_at, :format => :compact %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+      <%= paginate @products, total_count: @products.total_count %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/office/products/index.json.jbuilder
+++ b/app/views/office/products/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @products, partial: "office/products/product", as: :product

--- a/app/views/office/products/new.html.erb
+++ b/app/views/office/products/new.html.erb
@@ -1,0 +1,13 @@
+<%= render(
+  "common/headings/page",
+  breadcrumbs: [
+    { title: t("navigation.dashboard"), path: office_root_path },
+    { title: t("titles.product.index"), path: office_products_path },
+    { title: t("navigation.new"), path: new_office_product_path },
+  ],
+  title: t("titles.product.new"),
+) %>
+
+<div class="w-full">
+  <%= render "form", product: @product %>
+</div>

--- a/app/views/office/products/productables/_manufactured_product.html.erb
+++ b/app/views/office/products/productables/_manufactured_product.html.erb
@@ -1,0 +1,10 @@
+<%# locals(:productable) %>
+<%= render(
+  "common/lists/description",
+  items: [
+    { label: ManufacturedProduct.human_attribute_name(:formula), value: productable.formula_name },
+    { label: ManufacturedProduct.human_attribute_name(:shape), value: productable.shape },
+    { label: ManufacturedProduct.human_attribute_name(:size), value: productable.size },
+    { label: ManufacturedProduct.human_attribute_name(:weight), value: "#{number_with_precision productable.weight} kg" },
+  ]
+) %>

--- a/app/views/office/products/productables/_purchased_product.html.erb
+++ b/app/views/office/products/productables/_purchased_product.html.erb
@@ -1,0 +1,7 @@
+<%# locals(:productable) %>
+<%= render(
+  "common/lists/description",
+  items: [
+    { label: PurchasedProduct.human_attribute_name(:base_cost), value: number_to_currency(productable.base_cost) },
+  ]
+) %>

--- a/app/views/office/products/productables/_purchased_product_fields.html.erb
+++ b/app/views/office/products/productables/_purchased_product_fields.html.erb
@@ -1,0 +1,8 @@
+<%# locals(form:) %>
+
+<div>
+  <%= form.label :base_cost, class: "block text-sm font-medium leading-6 text-gray-900" %>
+  <div class="mt-2">
+    <%= form.number_field :base_cost, min: 0, step: 0.01, class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-300 focus:ring-2 focus:ring-inset focus:ring-blue-300 sm:text-sm sm:leading-6" %>
+  </div>
+</div>

--- a/app/views/office/products/show.html.erb
+++ b/app/views/office/products/show.html.erb
@@ -1,13 +1,13 @@
 <%= render(
   "common/headings/page",
   breadcrumbs: [
-    { title: t("navigation.dashboard"), path: factory_root_path },
-    { title: t("titles.product.index"), path: factory_products_path },
-    { title: @product.name, path: factory_product_path(@product) },
+    { title: t("navigation.dashboard"), path: office_root_path },
+    { title: t("titles.product.index"), path: office_products_path },
+    { title: @product.name, path: office_product_path(@product) },
   ],
   title: @product.name,
   actions: [
-    { label: t("navigation.edit"), path: edit_factory_product_path(@product), method: :get },
+    { label: t("navigation.edit"), path: edit_office_product_path(@product), method: :get },
   ],
 ) %>
 <div class="grid grid-cols-1 xl:grid-cols-2 gap-8 mt-6">
@@ -28,20 +28,10 @@
     <%= render(
       "common/lists/description",
       items: [
-        {
-          label: ManufacturedProduct.human_attribute_name(:formula),
-          block: -> {
-            link_to(factory_formula_path(@product.manufactured_product.formula), class: "font-semibold") do
-              "#{@product.manufactured_product.formula_name} (##{@product.manufactured_product.formula_id})"
-            end
-          },
-        },
-        { label: ManufacturedProduct.human_attribute_name(:shape), value: @product.manufactured_product.shape },
-        { label: ManufacturedProduct.human_attribute_name(:size), value: @product.manufactured_product.size },
-        { label: ManufacturedProduct.human_attribute_name(:weight), value: "#{number_with_precision(@product.manufactured_product.weight)} kg" },
-        { label: ManufacturedProduct.human_attribute_name(:pressure), value: @product.manufactured_product.pressure },
+        { label: Product.human_attribute_name(:price), value: number_to_currency(@product.price) },
       ]
     ) %>
+    <%= render "office/products/productables/#{@product.productable_name}", productable: @product.productable %>
   </div>
   <div>
     <div class="border-b border-light-gray-500 bg-white py-6 mb-6">

--- a/app/views/office/products/show.json.jbuilder
+++ b/app/views/office/products/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "office/products/product", product: @product

--- a/config/initializers/maintenance_tasks.rb
+++ b/config/initializers/maintenance_tasks.rb
@@ -1,0 +1,1 @@
+MaintenanceTasks.parent_controller = "ApplicationController"

--- a/config/locales/comman_es.yml
+++ b/config/locales/comman_es.yml
@@ -72,17 +72,25 @@ es:
       making_order_items:
         quantity: "Cantidad de producto"
       product:
+        created_at: "Ingresado"
+        current_stock: "Stock actual"
+        description: "Descripción"
         id: "ID"
+        max_stock: "Stock máximo"
+        min_stock: "Stock mínimo"
         name: "Nombre"
+        price: "Precio"
+        updated_at: "Actualizado"
+      manufactured_product:
+        formula_id: "Fórmula"
+        formula: "Fórmula"
+        pressure: "Presión"
+        product_detail: "Detalle"
         shape: "Forma"
         size: "Dimensiones"
         weight: "Peso"
-        pressure: "Presión"
-        price: "Precio"
-        formula: "Fórmula"
-        formula_id: "Fórmula"
-        updated_at: "Actualizado"
-        created_at: "Ingresado"
+      purchased_product:
+        base_cost: "Costo base"
       client:
         id: "ID"
         name: "Nombre"

--- a/config/locales/comman_es.yml
+++ b/config/locales/comman_es.yml
@@ -90,7 +90,7 @@ es:
         size: "Dimensiones"
         weight: "Peso"
       purchased_product:
-        base_cost: "Costo base"
+        base_cost: "Costo"
       client:
         id: "ID"
         name: "Nombre"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
   resource :session
   resources :passwords, param: :token
 
+  namespace :admin do
+    mount MaintenanceTasks::Engine, at: "/maintenance_tasks"
+  end
+
   namespace :office do
     root "dashboard#index"
     resources :clients

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     resources :clients
     get :settings, to: "settings#index"
     resources :discounts, only: %i[ show edit update ]
+    resources :products
   end
 
   namespace :sales do

--- a/db/migrate/20250213134713_update_products.rb
+++ b/db/migrate/20250213134713_update_products.rb
@@ -1,0 +1,10 @@
+class UpdateProducts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :products, :productable_type, :string
+    add_column :products, :productable_id, :integer
+    add_column :products, :current_stock, :integer, default: 0, null: false
+    add_column :products, :min_stock, :integer, default: 0, null: false
+    add_column :products, :max_stock, :integer, default: 0, null: false
+    add_column :products, :description, :text
+  end
+end

--- a/db/migrate/20250213152541_create_manufactured_products.rb
+++ b/db/migrate/20250213152541_create_manufactured_products.rb
@@ -1,0 +1,13 @@
+class CreateManufacturedProducts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :manufactured_products do |t|
+      t.references :formula, foreign_key: true
+      t.string :pressure
+      t.string :shape
+      t.string :size
+      t.decimal :weight
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250213153653_create_purchased_products.rb
+++ b/db/migrate/20250213153653_create_purchased_products.rb
@@ -1,0 +1,8 @@
+class CreatePurchasedProducts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :purchased_products do |t|
+      t.decimal :base_cost
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250213173747_create_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20250213173747_create_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20201211151756)
+class CreateMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
+  def change
+    create_table(:maintenance_tasks_runs) do |t|
+      t.string(:task_name, null: false)
+      t.datetime(:started_at)
+      t.datetime(:ended_at)
+      t.float(:time_running, default: 0.0, null: false)
+      t.integer(:tick_count, default: 0, null: false)
+      t.integer(:tick_total)
+      t.string(:job_id)
+      t.bigint(:cursor)
+      t.string(:status, default: :enqueued, null: false)
+      t.string(:error_class)
+      t.string(:error_message)
+      t.text(:backtrace)
+      t.timestamps
+      t.index(:task_name)
+      t.index([ :task_name, :created_at ], order: { created_at: :desc })
+    end
+  end
+end

--- a/db/migrate/20250213173748_change_cursor_to_string.maintenance_tasks.rb
+++ b/db/migrate/20250213173748_change_cursor_to_string.maintenance_tasks.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210219212931)
+class ChangeCursorToString < ActiveRecord::Migration[6.0]
+  # This migration will clear all existing data in the cursor column with MySQL.
+  # Ensure no Tasks are paused when this migration is deployed, or they will be resumed from the start.
+  # Running tasks are able to gracefully handle this change, even if interrupted.
+  def up
+    change_table(:maintenance_tasks_runs) do |t|
+      t.change(:cursor, :string)
+    end
+  end
+
+  def down
+    change_table(:maintenance_tasks_runs) do |t|
+      t.change(:cursor, :bigint)
+    end
+  end
+end

--- a/db/migrate/20250213173749_remove_index_on_task_name.maintenance_tasks.rb
+++ b/db/migrate/20250213173749_remove_index_on_task_name.maintenance_tasks.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210225152418)
+class RemoveIndexOnTaskName < ActiveRecord::Migration[6.0]
+  def up
+    change_table(:maintenance_tasks_runs) do |t|
+      t.remove_index(:task_name)
+    end
+  end
+
+  def down
+    change_table(:maintenance_tasks_runs) do |t|
+      t.index(:task_name)
+    end
+  end
+end

--- a/db/migrate/20250213173750_add_arguments_to_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20250213173750_add_arguments_to_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210517131953)
+class AddArgumentsToMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:maintenance_tasks_runs, :arguments, :text)
+  end
+end

--- a/db/migrate/20250213173751_add_lock_version_to_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20250213173751_add_lock_version_to_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20211210152329)
+class AddLockVersionToMaintenanceTasksRuns < ActiveRecord::Migration[6.0]
+  def change
+    add_column(
+      :maintenance_tasks_runs,
+      :lock_version,
+      :integer,
+      default: 0,
+      null: false,
+    )
+  end
+end

--- a/db/migrate/20250213173752_change_runs_tick_columns_to_bigints.maintenance_tasks.rb
+++ b/db/migrate/20250213173752_change_runs_tick_columns_to_bigints.maintenance_tasks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20220706101937)
+class ChangeRunsTickColumnsToBigints < ActiveRecord::Migration[6.0]
+  def up
+    change_table(:maintenance_tasks_runs, bulk: true) do |t|
+      t.change(:tick_count, :bigint)
+      t.change(:tick_total, :bigint)
+    end
+  end
+
+  def down
+    change_table(:maintenance_tasks_runs, bulk: true) do |t|
+      t.change(:tick_count, :integer)
+      t.change(:tick_total, :integer)
+    end
+  end
+end

--- a/db/migrate/20250213173753_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20250213173753_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20220713131925)
+class AddIndexOnTaskNameAndStatusToRuns < ActiveRecord::Migration[6.0]
+  def change
+    remove_index(
+      :maintenance_tasks_runs,
+      column: [ :task_name, :created_at ],
+      order: { created_at: :desc },
+      name: :index_maintenance_tasks_runs_on_task_name_and_created_at,
+    )
+
+    add_index(
+      :maintenance_tasks_runs,
+      [ :task_name, :status, :created_at ],
+      name: :index_maintenance_tasks_runs,
+      order: { created_at: :desc },
+    )
+  end
+end

--- a/db/migrate/20250213173754_add_metadata_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20250213173754_add_metadata_to_runs.maintenance_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20230622035229)
+class AddMetadataToRuns < ActiveRecord::Migration[6.0]
+  def change
+    add_column(:maintenance_tasks_runs, :metadata, :text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_07_210506) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_13_173754) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -67,6 +67,27 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_07_210506) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "maintenance_tasks_runs", force: :cascade do |t|
+    t.string "task_name", null: false
+    t.datetime "started_at", precision: nil
+    t.datetime "ended_at", precision: nil
+    t.float "time_running", default: 0.0, null: false
+    t.bigint "tick_count", default: 0, null: false
+    t.bigint "tick_total"
+    t.string "job_id"
+    t.string "cursor"
+    t.string "status", default: "enqueued", null: false
+    t.string "error_class"
+    t.string "error_message"
+    t.text "backtrace"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "arguments"
+    t.integer "lock_version", default: 0, null: false
+    t.text "metadata"
+    t.index ["task_name", "status", "created_at"], name: "index_maintenance_tasks_runs", order: { created_at: :desc }
+  end
+
   create_table "making_order_formula_items", force: :cascade do |t|
     t.integer "making_order_formula_id"
     t.integer "formula_item_id"
@@ -115,6 +136,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_07_210506) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "manufactured_products", force: :cascade do |t|
+    t.bigint "formula_id"
+    t.string "pressure"
+    t.string "shape"
+    t.string "size"
+    t.decimal "weight"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["formula_id"], name: "index_manufactured_products_on_formula_id"
+  end
+
   create_table "products", force: :cascade do |t|
     t.string "name"
     t.decimal "price"
@@ -123,6 +155,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_07_210506) do
     t.string "size"
     t.decimal "weight"
     t.string "pressure"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "productable_type"
+    t.integer "productable_id"
+    t.integer "current_stock", default: 0, null: false
+    t.integer "min_stock", default: 0, null: false
+    t.integer "max_stock", default: 0, null: false
+    t.text "description"
+  end
+
+  create_table "purchased_products", force: :cascade do |t|
+    t.decimal "base_cost"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -144,5 +188,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_07_210506) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "manufactured_products", "formulas"
   add_foreign_key "sessions", "users"
 end

--- a/spec/factories/formula_items.rb
+++ b/spec/factories/formula_items.rb
@@ -3,5 +3,9 @@ FactoryBot.define do
     formula
     formula_element
     proportion { 50 }
+
+    trait :with_element do
+      formula_element { association :formula_element }
+    end
   end
 end

--- a/spec/factories/formulas.rb
+++ b/spec/factories/formulas.rb
@@ -12,14 +12,11 @@ FactoryBot.define do
         items_proportions { [ 30.0, 70.0 ] }
       end
 
-      after(:build) do |formula, evaluator|
-        evaluator.items_proportions.each do |proportion|
-          formula.formula_items << build(
-            :formula_item,
-            formula: formula,
-            formula_element: create(:formula_element),
-            proportion: proportion,
-          )
+      formula_items do
+        Array.new(items_count) do |index|
+          association :formula_item, :with_element,
+            formula: instance,
+            proportion: items_proportions[index]
         end
       end
     end

--- a/spec/factories/making_order_items.rb
+++ b/spec/factories/making_order_items.rb
@@ -1,17 +1,21 @@
 FactoryBot.define do
   factory :making_order_item do
-    making_order
-    product
     quantity { 1 }
+    product
+    making_order
+
+    trait :with_making_order do
+      transient do
+        formula { association :formula, :with_items }
+      end
+      making_order { association :making_order, formula: formula, making_order_items: [ instance ] }
+    end
 
     trait :with_product do
       transient do
-        product { create(:product, formula: making_order.formula) }
+        formula { making_order.formula }
       end
-
-      after(:build) do |making_order_item, evaluator|
-        making_order_item.product = evaluator.product
-      end
+      product { association :manufactured_productable, formula: formula }
     end
   end
 end

--- a/spec/factories/making_orders.rb
+++ b/spec/factories/making_orders.rb
@@ -3,25 +3,39 @@ FactoryBot.define do
     comments { Faker::Lorem.sentence }
     mixer_capacity { 60.0 }
     state { :in_progress }
+    transient do
+      formula { association :formula, :with_items }
+    end
+    transient do
+      formula_id { formula&.id }
+    end
+    making_order_formula do
+      association :making_order_formula, formula: formula, formula_id: formula_id, making_order: instance
+    end
 
     trait :with_products do
       transient do
         products_count { 2 }
       end
-
-      after(:build) do |making_order, evaluator|
-        making_order.making_order_formula = build(
-          :making_order_formula,
-          formula: create(:formula, :with_items),
-        )
-
-        making_order.making_order_items = build_list(
-          :making_order_item,
-          evaluator.products_count,
-          :with_product,
-          making_order: making_order,
-        )
+      making_order_items do
+        Array.new(products_count) do
+          association :making_order_item, :with_product, making_order: instance, formula: formula
+        end
       end
+
+      # after(:build) do |making_order, evaluator|
+      #   # making_order.making_order_formula = build(
+      #   #   :making_order_formula,
+      #   #   formula: create(:formula, :with_items),
+      #   # )
+
+      #   # making_order.making_order_items = build_list(
+      #   #   :making_order_item,
+      #   #   evaluator.products_count,
+      #   #   :with_product,
+      #   #   making_order: making_order,
+      #   # )
+      # end
     end
   end
 end

--- a/spec/factories/manufactured_products.rb
+++ b/spec/factories/manufactured_products.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :manufactured_product do
+    pressure { "G#{Faker::Number.number(digits: 2)}" }
+    shape { Faker::Alphanumeric.alpha(number: 2) }
+    size { "#{ Faker::Number.number(digits: 2)}x#{ Faker::Number.number(digits: 2)}x#{ Faker::Number.number(digits: 2)}" }
+    weight { Faker::Number.number(digits: 2) }
+    formula { association :formula, :with_items }
+  end
+end

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -1,10 +1,20 @@
 FactoryBot.define do
   factory :product do
     price { Faker::Commerce.price }
-    formula
-    shape { Faker::Alphanumeric.alpha(number: 2) }
-    size { "#{ Faker::Number.number(digits: 2)}x#{ Faker::Number.number(digits: 2)}x#{ Faker::Number.number(digits: 2)}" }
-    weight { Faker::Number.number(digits: 2) }
-    pressure { "G#{Faker::Number.number(digits: 2)}" }
+  end
+
+  factory :manufactured_productable, parent: :product do
+    transient { formula { association :formula, :with_items } }
+    transient { pressure { "G#{Faker::Number.number(digits: 2)}" } }
+    transient { shape { Faker::Alphanumeric.alpha(number: 2) } }
+    transient { size { "#{ Faker::Number.number(digits: 2)}x#{ Faker::Number.number(digits: 2)}x#{ Faker::Number.number(digits: 2)}" } }
+    transient { weight { Faker::Number.number(digits: 2) } }
+    productable { association :manufactured_product, formula: formula, pressure: pressure, shape: shape, size: size, weight: weight }
+  end
+
+  factory :purchased_productable, parent: :product do
+    name { Faker::Commerce.product_name }
+    transient { base_cost { Faker::Commerce.price } }
+    productable { association :purchased_product, base_cost: base_cost }
   end
 end

--- a/spec/factories/purchased_products.rb
+++ b/spec/factories/purchased_products.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :purchased_product do
+    base_cost { Faker::Commerce.price }
+  end
+end

--- a/spec/models/discount_spec.rb
+++ b/spec/models/discount_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Discount, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/making_order_formula_item_spec.rb
+++ b/spec/models/making_order_formula_item_spec.rb
@@ -4,7 +4,7 @@ describe MakingOrderFormulaItem, type: :model do
   let(:formula_element) { create(:formula_element, current_stock: 100) }
   let(:formula) { create(:formula, formula_items: [ formula_item ]) }
   let(:formula_item) { build(:formula_item, formula_element: formula_element, proportion: 100) }
-  let(:product) { create(:product, formula: formula, weight: 10.0) }
+  let(:product) { create(:manufactured_productable, formula: formula, weight: 10.0) }
   let(:making_order_formula) { build(:making_order_formula, formula: formula, making_order_formula_items: [ making_order_formula_item ]) }
   let(:making_order_formula_item) { build(:making_order_formula_item, formula_item: formula_item, proportion: 100) }
   let(:making_order_item) { build(:making_order_item, product: product) }

--- a/spec/models/making_order_formula_spec.rb
+++ b/spec/models/making_order_formula_spec.rb
@@ -1,5 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe MakingOrderFormula, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'prepare attributes before save' do
+    let(:formula) { create(:formula, :with_items, items_count: 3, items_proportions: [ 10, 50, 40 ]) }
+    let(:formula_item1) { formula.formula_items.first }
+    let(:formula_item2) { formula.formula_items.second }
+    let(:formula_item3) { formula.formula_items.third }
+    let(:making_order) { create(:making_order, :with_products, formula: formula) }
+    let(:making_order_formula) { build(:making_order_formula, formula: formula, making_order: making_order) }
+
+    before { making_order_formula.valid? }
+
+    it 'builds making_order_formula_items from formula items' do
+      expect(making_order_formula.making_order_formula_items.first.proportion).to eq(formula_item1.proportion)
+      expect(making_order_formula.making_order_formula_items.first.formula_element_id).to eq(formula_item1.formula_element_id)
+      expect(making_order_formula.making_order_formula_items.first.formula_element_name).to eq(formula_item1.formula_element_name)
+      expect(making_order_formula.making_order_formula_items.first.formula_item_id).to eq(formula_item1.id)
+      expect(making_order_formula.making_order_formula_items.second.proportion).to eq(formula_item2.proportion)
+      expect(making_order_formula.making_order_formula_items.second.formula_element_id).to eq(formula_item2.formula_element_id)
+      expect(making_order_formula.making_order_formula_items.second.formula_element_name).to eq(formula_item2.formula_element_name)
+      expect(making_order_formula.making_order_formula_items.second.formula_item_id).to eq(formula_item2.id)
+      expect(making_order_formula.making_order_formula_items.third.proportion).to eq(formula_item3.proportion)
+      expect(making_order_formula.making_order_formula_items.third.formula_element_id).to eq(formula_item3.formula_element_id)
+      expect(making_order_formula.making_order_formula_items.third.formula_element_name).to eq(formula_item3.formula_element_name)
+      expect(making_order_formula.making_order_formula_items.third.formula_item_id).to eq(formula_item3.id)
+    end
+
+    it 'does not build making_order_formula_items' do
+      expect(making_order_formula.formula_name).to eq(formula.name)
+      expect(making_order_formula.formula_abrasive).to eq(formula.abrasive)
+      expect(making_order_formula.formula_grain).to eq(formula.grain)
+      expect(making_order_formula.formula_hardness).to eq(formula.hardness)
+      expect(making_order_formula.formula_porosity).to eq(formula.porosity)
+      expect(making_order_formula.formula_alloy).to eq(formula.alloy)
+    end
+  end
 end

--- a/spec/models/making_order_item_spec.rb
+++ b/spec/models/making_order_item_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe MakingOrderItem, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "stores product fields" do
+    product = create(:manufactured_productable)
+    making_order_item = create(:making_order_item, :with_making_order, product: product, formula: product.productable.formula)
+    expect(making_order_item.product_name).to eq(making_order_item.product.name)
+    expect(making_order_item.product_shape).to eq(making_order_item.product.productable.shape)
+    expect(making_order_item.product_pressure).to eq(making_order_item.product.productable.pressure)
+    expect(making_order_item.product_size).to eq(making_order_item.product.productable.size)
+    expect(making_order_item.product_weight).to eq(making_order_item.product.productable.weight)
+  end
 end

--- a/spec/models/making_order_spec.rb
+++ b/spec/models/making_order_spec.rb
@@ -1,5 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe MakingOrder, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:formula) { create(:formula, :with_items) }
+  let(:product1) { create(:manufactured_productable, formula: formula, weight: 10) }
+  let(:product2) { create(:manufactured_productable, formula: formula, weight: 4) }
+  let(:making_order_items) do
+    [
+      build(:making_order_item, product: product1, quantity: 2),
+      build(:making_order_item, product: product2, quantity: 1),
+    ]
+  end
+  let(:making_order) do
+    build(
+      :making_order,
+      formula: nil,
+      formula_id: formula.id,
+      making_order_formula: nil,
+      making_order_items: making_order_items,
+      mixer_capacity: 20,
+    )
+  end
+
+  before { making_order.valid? }
+
+  it "sets formula" do
+    expect(making_order.making_order_formula.formula_id).to eq(formula.id)
+  end
+
+  it "sets total weight" do
+    expect(making_order.total_weight).to eq(24)
+  end
+
+  it "sets rounds count" do
+    expect(making_order.rounds_count).to eq(2)
+  end
+
+  it "sets weight per round" do
+    expect(making_order.weight_per_round).to eq(12)
+  end
+
+  it "sets formula dirty" do
+    making_order.total_weight = 200
+    making_order.valid?
+    making_order.making_order_formula_items.each do |item|
+      expect(item.consumed_stock_changed?).to eq(false)
+    end
+  end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,5 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe Product, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'validations' do
+    it 'is valid with valid attributes' do
+      product = build(:product, name: 'ValidName', productable: build(:purchased_product))
+      expect(product).to be_valid
+    end
+
+    it 'is not valid without a name' do
+      product = build(:product, name: nil, productable: build(:purchased_product))
+      expect(product).not_to be_valid
+      expect(product.errors[:name]).to include("no puede estar en blanco")
+    end
+
+    it 'is not valid with a duplicate name' do
+      create(:product, name: 'UniqueName', productable: build(:purchased_product))
+      product = build(:product, name: 'UniqueName', productable: build(:purchased_product))
+      expect(product).not_to be_valid
+      expect(product.errors[:base]).to include(I18n.t(:name_must_be_unique, scope: [ :activerecord, :errors, :models, :product ], other_product_id: Product.find_by(name: 'UniqueName').id, other_product_name: 'UniqueName'))
+    end
+  end
 end

--- a/spec/requests/factory/making_orders_spec.rb
+++ b/spec/requests/factory/making_orders_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "/factory/making_orders", type: :request do
-  let(:product) { create(:product, formula: formula) }
   let(:formula) { create(:formula, :with_items) }
+  let(:product) { create(:manufactured_productable, formula: formula) }
 
   let(:valid_attributes) {
     {

--- a/spec/requests/office/products_spec.rb
+++ b/spec/requests/office/products_spec.rb
@@ -1,0 +1,283 @@
+require 'rails_helper'
+
+RSpec.describe "/office/products", type: :request do
+  let(:valid_attributes) {
+    {
+      current_stock: 5,
+      max_stock: 10,
+      min_stock: 5,
+      name: "Product Name",
+      price: 14.0,
+      productable_type: "PurchasedProduct",
+      productable_attributes: {
+        base_cost: 20.0,
+      },
+    }
+  }
+
+  let(:invalid_attributes) {
+    {
+      current_stock: "Nothing left",
+      max_stock: "Ten",
+      min_stock: "Five",
+      name: nil,
+      productable_type: "PurchasedProduct",
+      productable_attributes: {
+        base_cost: "Twenty",
+      },
+    }
+  }
+
+  before { sign_in create(:user) }
+
+  describe "GET /index" do
+    it "renders a successful response" do
+      create(:purchased_productable)
+      get office_products_url
+      expect(response).to be_successful
+    end
+
+    context "with IdSearchQueryProcessor" do
+      let!(:product1) do
+        create(
+          :purchased_productable,
+          base_cost: 20.0,
+          id: 1234,
+          name: "Purchase One",
+        )
+      end
+      let!(:product2) do
+        create(
+          :purchased_productable,
+          id: 5678,
+          base_cost: 11.0,
+          name: "Free Two",
+        )
+      end
+      let!(:product3) do
+        create(
+          :manufactured_productable,
+          id: 6789,
+          name: "Manufactured Three",
+        )
+      end
+
+      context "when params[:q] contains id_or_name_cont with #1234" do
+        it "filters by ID" do
+          get office_products_url, params: { q: { "id_or_name_cont" => "#1234" } }, as: :json
+
+          json_response = JSON.parse(response.body)
+          expect(response).to be_successful
+          expect(json_response.pluck("name")).to eq([ "Purchase One" ])
+        end
+      end
+
+      context "when params[:q] contains id_or_description_cont with #5678" do
+        it "filters by ID" do
+          get office_products_url, params: { q: { "id_or_description_cont" => "#5678" } }, as: :json
+
+          json_response = JSON.parse(response.body)
+          expect(response).to be_successful
+          expect(json_response.pluck("name")).to eq([ "Free Two" ])
+        end
+      end
+
+      context "when params[:q] does not contain any id_or_* keys" do
+        it "returns Purchase products" do
+          get office_products_url, params: { q: { "name_cont" => "Purchase" } }, as: :json
+
+          json_response = JSON.parse(response.body)
+          expect(response).to be_successful
+          expect(json_response.pluck("id")).to match_array([ product1.id ])
+        end
+      end
+
+      context "when params[:q] contains id_or_* keys but the value is missing the id" do
+        it "returns no products" do
+          get office_products_url, params: { q: { "id_or_name_cont" => "1234" } }, as: :json
+
+          json_response = JSON.parse(response.body)
+          expect(response).to be_successful
+          expect(json_response.pluck("id")).to match_array([])
+        end
+      end
+    end
+  end
+
+  describe "GET /show" do
+    it "renders a successful response" do
+      product = create(:purchased_productable)
+      get office_product_url(product)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /new" do
+    it "renders a successful response" do
+      get new_office_product_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /edit" do
+    it "renders a successful response" do
+      product = create(:purchased_productable)
+      get edit_office_product_url(product)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST /create" do
+    context "with valid parameters" do
+      it "creates a new Product" do
+        expect {
+          post office_products_url, params: { product: valid_attributes }
+        }.to change(Product, :count).by(1)
+        .and change(PurchasedProduct, :count).by(1)
+      end
+
+      it "redirects to the created product" do
+        post office_products_url, params: { product: valid_attributes }
+        expect(response).to redirect_to(office_product_url(Product.last))
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not create a new Product" do
+        expect {
+          post office_products_url, params: { product: invalid_attributes }
+        }.to change(Product, :count).by(0)
+        .and change(PurchasedProduct, :count).by(0)
+      end
+
+      it "renders a response with 422 status (i.e. to display the 'new' template)" do
+        post office_products_url, params: { product: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      let(:new_attributes) {
+        {
+          name: "New Product Name",
+          productable_attributes: {
+            base_cost: 55.5,
+          },
+        }
+      }
+
+      it "updates the requested product" do
+        product = create(:purchased_productable)
+        patch office_product_url(product), params: { product: new_attributes }
+        product.reload
+        expect(product.name).to eq("New Product Name")
+        expect(product.productable.base_cost).to eq(55.5)
+      end
+
+      it "redirects to the product" do
+        product = create(:purchased_productable)
+        patch office_product_url(product), params: { product: new_attributes }
+        product.reload
+        expect(response).to redirect_to(office_product_url(product))
+      end
+    end
+
+    context "with invalid parameters" do
+      it "renders a response with 422 status (i.e. to display the 'edit' template)" do
+        product = create(:purchased_productable)
+        patch office_product_url(product), params: { product: invalid_attributes }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "productable is a ManufacturedProduct" do
+      it "updates manufactured product allowed attributes" do
+        product = create(:manufactured_productable)
+        original_name = product.name
+        original_formula_id = product.productable.formula_id
+        original_pressure = product.productable.pressure
+        original_shape = product.productable.shape
+        original_size = product.productable.size
+        original_weight = product.productable.weight
+
+        patch office_product_url(product), params: {
+          product: {
+            current_stock: 1,
+            description: "New Description",
+            max_stock: 3,
+            min_stock: 2,
+            name: "not allowed",
+            price: 66.6,
+            productable_attributes: {
+              formula_id: 4,
+              pressure: "not allowed",
+              shape: "not allowed",
+              size: "not allowed",
+              weight: "not allowed",
+            },
+          },
+        }
+        product.reload
+        expect(product.current_stock).to eq(1)
+        expect(product.description).to eq("New Description")
+        expect(product.max_stock).to eq(3)
+        expect(product.min_stock).to eq(2)
+        expect(product.name).to eq(original_name)
+        expect(product.price).to eq(66.6)
+        expect(product.productable.formula_id).to eq(original_formula_id)
+        expect(product.productable.pressure).to eq(original_pressure)
+        expect(product.productable.shape).to eq(original_shape)
+        expect(product.productable.size).to eq(original_size)
+        expect(product.productable.weight).to eq(original_weight)
+      end
+
+      it "updates manufactured product allowed attributes" do
+        product = create(:purchased_productable)
+
+        patch office_product_url(product), params: {
+          product: {
+            current_stock: 1,
+            description: "New Description",
+            max_stock: 3,
+            min_stock: 2,
+            name: "New Name",
+            price: 66.6,
+            productable_attributes: {
+              base_cost: 12.1,
+              pressure: "not allowed",
+              shape: "not allowed",
+              size: "not allowed",
+              weight: "not allowed",
+            },
+          },
+        }
+        product.reload
+        expect(product.current_stock).to eq(1)
+        expect(product.description).to eq("New Description")
+        expect(product.max_stock).to eq(3)
+        expect(product.min_stock).to eq(2)
+        expect(product.name).to eq("New Name")
+        expect(product.price).to eq(66.6)
+        expect(product.productable.base_cost).to eq(12.1)
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    it "destroys the requested product" do
+      product = create(:purchased_productable)
+      expect {
+        delete office_product_url(product)
+      }.to change(Product, :count).by(-1)
+      .and change(PurchasedProduct, :count).by(-1)
+    end
+
+    it "redirects to the products list" do
+      product = create(:purchased_productable)
+      delete office_product_url(product)
+      expect(response).to redirect_to(office_products_url)
+    end
+  end
+end

--- a/spec/routing/factory/products_routing_spec.rb
+++ b/spec/routing/factory/products_routing_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe Factory::ProductsController, type: :routing do
       expect(get: "/factory/products/1/edit").to route_to("factory/products#edit", id: "1")
     end
 
-
     it "routes to #create" do
       expect(post: "/factory/products").to route_to("factory/products#create")
     end

--- a/spec/routing/office/products_routing_spec.rb
+++ b/spec/routing/office/products_routing_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Office::ProductsController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/office/products").to route_to("office/products#index")
+    end
+
+    it "routes to #new" do
+      expect(get: "/office/products/new").to route_to("office/products#new")
+    end
+
+    it "routes to #show" do
+      expect(get: "/office/products/1").to route_to("office/products#show", id: "1")
+    end
+
+    it "routes to #edit" do
+      expect(get: "/office/products/1/edit").to route_to("office/products#edit", id: "1")
+    end
+
+    it "routes to #create" do
+      expect(post: "/office/products").to route_to("office/products#create")
+    end
+
+    it "routes to #update via PUT" do
+      expect(put: "/office/products/1").to route_to("office/products#update", id: "1")
+    end
+
+    it "routes to #update via PATCH" do
+      expect(patch: "/office/products/1").to route_to("office/products#update", id: "1")
+    end
+
+    it "routes to #destroy" do
+      expect(delete: "/office/products/1").to route_to("office/products#destroy", id: "1")
+    end
+  end
+end

--- a/spec/tasks/maintenance/set_product_price_to_0_when_null_task_spec.rb
+++ b/spec/tasks/maintenance/set_product_price_to_0_when_null_task_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe SetProductPriceTo0WhenNullTask do
+    describe "#process" do
+      subject(:process) { described_class.process(element) }
+      let(:formula_element) { create(:formula_element, current_stock: 100) }
+      let(:formula) { create(:formula, formula_items: [ formula_item ]) }
+      let(:formula_item) { build(:formula_item, formula_element: formula_element, proportion: 100) }
+      let(:element) do
+        product = Product.new({
+          formula: formula,
+          price: 20.0,
+        })
+        product.save!(validate: false)
+        product
+      end
+
+      it "sets the price to 0 if it is nil" do
+        element.update_column(:price, nil)
+        expect(element.reload.price).to be_nil
+        process
+        expect(element.reload.price).to eq(0)
+      end
+
+      it "skips the product if the price is not nil" do
+        element.update_column(:price, 10)
+        expect(element.reload.price).to eq(10)
+        process
+        expect(element.reload.price).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/tasks/maintenance/split_product_into_polymorphic_associations_task_spec.rb
+++ b/spec/tasks/maintenance/split_product_into_polymorphic_associations_task_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe SplitProductIntoPolymorphicAssociationsTask do
+    describe "#process" do
+      subject(:process) { described_class.process(element) }
+      let(:formula_element) { create(:formula_element, current_stock: 100) }
+      let(:formula) { create(:formula, formula_items: [ formula_item ]) }
+      let(:formula_item) { build(:formula_item, formula_element: formula_element, proportion: 100) }
+      let(:element) do
+        product = Product.new({
+          formula: formula,
+          pressure: "high",
+          shape: "square",
+          size: "10x10",
+          weight: 10.0,
+        })
+        product.save!(validate: false)
+        product
+      end
+
+      it "creates a ManufacturedProductDetail" do
+        expect { process }.to change(ManufacturedProduct, :count).by(1)
+        expect(ManufacturedProduct.last.formula).to eq(formula)
+        expect(ManufacturedProduct.last.pressure).to eq("high")
+        expect(ManufacturedProduct.last.shape).to eq("square")
+        expect(ManufacturedProduct.last.size).to eq("10x10")
+        expect(ManufacturedProduct.last.weight).to eq(10.0)
+        expect(ManufacturedProduct.last.product).to eq(element)
+      end
+
+      it "prevents creating a ManufacturedProduct if the product already has a productable" do
+        element.productable = create(:manufactured_product)
+        element.save
+
+        expect { process }.not_to change(ManufacturedProduct, :count)
+      end
+
+      it "won't create a ManufacturedProduct if the product is not valid" do
+        element.price = "zero"
+        expect { process }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { process }.not_to change(ManufacturedProduct, :count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This pull request introduces several significant changes to the `Product` model and its associated controllers, views, and helpers. The main focus is on implementing polymorphic associations for products to separate those manufactured in the company from those purchased for reselling.

### Maintenance Tasks
Added the `maintenance_tasks` gem, which helps run and organize data migrations. The UI can be accessed through the /admin/maintenance_tasks route


## Deployment Notes
* [`app/tasks/maintenance/set_product_price_to_0_when_null_task.rb`](diffhunk://#diff-c966727f6a01aedbe6c07db860641df068d1e8c8b113dec0186a653570947756R1-R19): Introduced a maintenance task to set the price of products to 0 when it is null.
* [`app/tasks/maintenance/split_product_into_polymorphic_associations_task.rb`](diffhunk://#diff-0d028310f4b9576b69e4b69877b6ae6da0ee914146c961c02f26ff731eb5ab71R1-R26): Added a maintenance task to attach to existing products the manufactured_product polymorphic association.

<!-- Provide any specific deployment notes or steps that need to be taken post-merge. -->
