### PR TITLE
Fix: product formula update and dropdown typeahead

### DIFF
--- a/app/views/factory/products/_form.html.erb
+++ b/app/views/factory/products/_form.html.erb
@@ -40,7 +40,7 @@
           <div class="mt-2">
             <%= render("common/components/dropdown",
               placeholder: t("helpers.select.prompt", model: Formula.model_name.human),
-              input_name: "product[formula_id]",
+              input_name: "product[productable_attributes][formula_id]",
               input_value: product.productable.formula_id,
               search_value: product&.productable&.formula_name,
               input_classes: "text-xs #{'ring-red' if product.errors.any?}",

--- a/spec/requests/factory/products_spec.rb
+++ b/spec/requests/factory/products_spec.rb
@@ -181,10 +181,12 @@ RSpec.describe "/factory/products", type: :request do
 
       it "updates the requested product" do
         product = create(:manufactured_productable)
+
         patch factory_product_url(product), params: { product: new_attributes }
         product.reload
         expect(product.current_stock).to eq(27)
         expect(product.productable.shape).to eq("OO")
+        expect(product.productable.formula_id).to eq(formula.id)
       end
 
       it "redirects to the product" do


### PR DESCRIPTION
## Summary

This pull request fixes an issue with the attribute name for manufactured product formula.
It also improves the dropdown typeahead by making it more robust under poor internet connections.

### Dropdown Controller Enhancements:

* [`app/javascript/controllers/common/dropdown_controller.js`](diffhunk://#diff-2de13ce4519ec73db999767fe5afaf98386f96c1966dbc97175319f0050577a5R32-R35): Added logic to handle the abortion of ongoing fetch requests using an `AbortController` to prevent memory leaks and ensure proper cleanup. [[1]](diffhunk://#diff-2de13ce4519ec73db999767fe5afaf98386f96c1966dbc97175319f0050577a5R32-R35) [[2]](diffhunk://#diff-2de13ce4519ec73db999767fe5afaf98386f96c1966dbc97175319f0050577a5R103-R108) [[3]](diffhunk://#diff-2de13ce4519ec73db999767fe5afaf98386f96c1966dbc97175319f0050577a5L109-R133)

### Form Input Name Update:

* [`app/views/factory/products/_form.html.erb`](diffhunk://#diff-e28fec6447b657b3e78f68add58fe995a1949e9d0ccada34b2d4d9e0b836a6eeL43-R43): Updated the input name for the product formula ID to reflect the nested attributes structure, ensuring the correct parameter is sent in the form submission.

### Request Specs Improvement:

* [`spec/requests/factory/products_spec.rb`](diffhunk://#diff-9673cf2fada3796ad05e8ae7fcc4e501bb8e04b975fbd7f32c14026530f1b6f7R184-R189): Added an expectation to verify that the `formula_id` is correctly updated when a product is patched, ensuring the integrity of product updates.

