### PR TITLE
Set up for demo server deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@
 
 /node_modules
 .DS_Store
+
+# Ignore deploy environment files
+/config/deploy.*.yml
+!/config/deploy.yml

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 - Client, Product, and Order management
 - Manufacturing tracking and formula management
 - Inventory control and supplier handling
-- Dashboard with production charts
-- Role-based access for administrators, salespeople, operators, and clients
 - Optimized for desktop and mobile usage
 
 ## Tech Stack
@@ -48,6 +46,19 @@ bin/rspec
 kamal deploy
 ```
 
+### Deploying to a New Instance
+Each deployment environment (e.g. a specific client or demo instance) uses its own config/deploy.[newserver].yml file.
+
+#### To set up a new instance:
+```bash
+cp config/deploy.yml config/deploy.newserver.yml
+```
+
+#### Customize the new file with environment-specific values:
+- Server IP or hostname
+- Docker image tag
+- Volumes, environment variables, secrets, etc.
+
 ## Future Roadmap
 
 - Client request → Order flow:
@@ -57,3 +68,5 @@ kamal deploy
 - Billing and invoicing
 - Supplier price list importer
 - Quick access to resources using mobile camera + QR codes
+- Dashboard with production charts
+- Role-based access for administrators, salespeople, and operators

--- a/README.md
+++ b/README.md
@@ -1,7 +1,59 @@
 # Comman
 
-Company Manager
+**Comman** (short for "Company Manager") is a web application designed to streamline manufacturing, inventory, and sales operations for companies that produce and sell industrial products such as grinding stones, cutting discs, and hardware supplies.
 
-## Deployment
+## Features
 
-    kamal deploy
+- Client, Product, and Order management
+- Manufacturing tracking and formula management
+- Inventory control and supplier handling
+- Dashboard with production charts
+- Role-based access for administrators, salespeople, operators, and clients
+- Optimized for desktop and mobile usage
+
+## Tech Stack
+
+- Ruby on Rails 8
+- PostgreSQL
+- TailwindCSS
+- Hotwire (Turbo + Stimulus)
+- RSpec for testing
+
+## Setup Instructions
+
+#### Clone the repository
+```bash
+git clone https://github.com/damianfarina/comman.git && cd comman
+```
+#### Setup dependencies and database
+```bash
+bin/setup && bin/rails db:seed
+```
+- bin/setup installs Ruby gems, prepares the database, and runs migrations.
+- bin/rails db:seed populates the database with essential initial data, including:
+  - Default user
+  - Default discounts
+  - Default in-house supplier
+
+#### Run the server
+```bash
+bin/rails s
+```
+#### Run tests
+```bash
+bin/rspec
+```
+#### Deploy to production
+```bash
+kamal deploy
+```
+
+## Future Roadmap
+
+- Client request → Order flow:
+  - Create orders from client requests
+  - Automatically calculate stock availability
+  - Trigger Making Orders for missing stock
+- Billing and invoicing
+- Supplier price list importer
+- Quick access to resources using mobile camera + QR codes

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -8,7 +8,7 @@ image: damianfarina/comman
 servers:
   web:
     hosts:
-      - comman.unibras.com.ar
+      - commanapp.dev
     # options:
       # publish: "4001:4001"
   # job:
@@ -22,7 +22,7 @@ servers:
 # Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 proxy:
   ssl: true
-  host: comman.unibras.com.ar
+  host: commanapp.dev
 
 # Credentials for your image host.
 registry:
@@ -80,7 +80,7 @@ aliases:
 # Use a persistent storage volume for sqlite database files and local Active Storage files.
 # Recommended to change this to a mounted volume path that is backed up off server.
 volumes:
-  - "comman_storage:/rails/storage"
+  - "/srv/comman/storage:/rails/storage"
 
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old
@@ -117,7 +117,7 @@ ssh:
 accessories:
   db:
     image: postgres:17
-    host: comman.unibras.com.ar
+    host: commanapp.dev
     # Change to 5432 to expose port to the world instead of just local network.
     port: "127.0.0.1:5432:5432"
     env:
@@ -127,13 +127,13 @@ accessories:
       secret:
         - POSTGRES_PASSWORD
     directories:
-      - data:/var/lib/postgresql/data
+      - /srv/comman/postgres/data:/var/lib/postgresql/data
     files:
       - db/production_setup.sql:/docker-entrypoint-initdb.d/setup.sql
 
   postgres_backup:
     image: kartoza/pg-backup:17-3.5
-    host: comman.unibras.com.ar
+    host: commanapp.dev
     env:
       clear:
         POSTGRES_USER: comman
@@ -145,4 +145,4 @@ accessories:
       secret:
         - POSTGRES_PASS
     directories:
-      - backups:/backups
+      - /srv/comman/postgres/backups:/backups

--- a/docs/recover_db_backup.md
+++ b/docs/recover_db_backup.md
@@ -13,19 +13,19 @@
     ```
 1. Copy the db dump file to the server
 
-    `scp comman_db.backup user@comman.unibras.com.ar:`
+    `scp commanapp_db.backup user@commanapp.dev:`
 
-1. SSH into the server and copy the dump file to the comman_db container
+1. SSH into the server and copy the dump file to the commanapp_db container
 
-    `docker cp comman_db.backup comman-db:/tmp`
+    `docker cp commanapp_db.backup commanapp-db:/tmp`
 
 1. Log into the docker container
 
-    `docker exec -it comman-db bash`
+    `docker exec -it commanapp-db bash`
 
 1. Restore the tables needed
 
-    `pg_restore --data-only --table=formula_elements --table=formula_items --table=formulas --table=making_order_formula_items --table=making_order_formulas --table=making_order_items --table=making_orders --table=products -U comman -d comman_production /tmp/comman_db.backup`
+    `pg_restore --data-only --table=formula_elements --table=formula_items --table=formulas --table=making_order_formula_items --table=making_order_formulas --table=making_order_items --table=making_orders --table=products -U comman -d comman_production /tmp/commanapp_db.backup`
 
 1. Update sequences to point to the next available id
 


### PR DESCRIPTION
## Summary

This PR begins the process of deploying a generic demo instance of Comman, intended for showcasing and walking through the app with potential clients or businesses.

Key changes:
- Removed Unibras-specific configuration from the main deploy.yml.
- Each environment (e.g. unibras, demo, etc.) will now use its own deploy.[env].yml file.
- These files are meant to extend from the base deploy.yml and will be kept outside version control to avoid leaking sensitive credentials or environment-specific details.
- Updated the README.md and config/deploy.yml accordingly to reflect this new structure.

This sets the stage for flexible, secure deployments of multiple isolated instances.