### PR TITLE
[WIP] Audit Logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem "image_processing", "~> 1.2"
 gem "kaminari"
 gem "ransack"
 gem "chartkick"
+gem "paper_trail"
 gem "maintenance_tasks"
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :development, :test do
   gem "faker"
   gem "rubocop", require: false
   gem "rubocop-rails", require: false
+  gem "hotwire-spark"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,9 @@ GEM
     nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.1)
+    paper_trail (16.0.0)
+      activerecord (>= 6.1)
+      request_store (~> 1.4)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
@@ -308,6 +311,8 @@ GEM
     regexp_parser (2.10.0)
     reline (0.6.1)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     requestjs-rails (0.0.13)
       railties (>= 7.1.0)
     rexml (3.4.1)
@@ -459,6 +464,7 @@ DEPENDENCIES
   kamal
   kaminari
   maintenance_tasks
+  paper_trail
   pg (~> 1.5)
   propshaft
   puma (>= 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,10 @@ GEM
     heroicons (2.1.1)
       nokogiri
       railties (>= 5.2)
+    hotwire-spark (0.1.13)
+      listen
+      rails (>= 7.0.0)
+      zeitwerk
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -183,6 +187,9 @@ GEM
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     loofah (2.24.0)
       crass (~> 1.0.2)
@@ -306,6 +313,9 @@ GEM
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
     rdoc (6.13.1)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
@@ -458,6 +468,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   heroicons (~> 2.1)
+  hotwire-spark
   image_processing (~> 1.2)
   importmap-rails
   jbuilder

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,16 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_department
 
+  before_action :set_paper_trail_whodunnit
+
+  def user_for_paper_trail
+    Current.user.id if authenticated?
+  end
+
+  def info_for_paper_trail
+    { department: current_department }
+  end
+
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
 
   # FIXME: Enable the feature.

--- a/app/controllers/office/clients_controller.rb
+++ b/app/controllers/office/clients_controller.rb
@@ -11,6 +11,11 @@ module Office
 
     # GET /clients/1
     def show
+      @recent_activities = PaperTrail::Version
+        .where(item_type: Client.name, item_id: @client.id)
+        .order(created_at: :desc)
+      user_ids = @recent_activities.pluck(:whodunnit).compact.uniq
+      @version_user_names = User.where(id: user_ids).pluck(:id, :name).to_h
     end
 
     # GET /clients/1/edit

--- a/app/controllers/office/dashboard_controller.rb
+++ b/app/controllers/office/dashboard_controller.rb
@@ -1,6 +1,9 @@
 module Office
   class DashboardController < ApplicationController
     def index
+      @recent_activities = PaperTrail::Version.order(created_at: :desc).limit(10)
+      user_ids = @recent_activities.pluck(:whodunnit).compact.uniq
+      @version_user_names = User.where(id: user_ids).pluck(:id, :name).to_h
     end
   end
 end

--- a/app/controllers/office/suppliers_controller.rb
+++ b/app/controllers/office/suppliers_controller.rb
@@ -13,6 +13,11 @@ module Office
 
     # GET /office/suppliers/1 or /office/suppliers/1.json
     def show
+      @recent_activities = PaperTrail::Version
+        .where(item_type: Supplier.name, item_id: @supplier.id)
+        .order(created_at: :desc)
+      user_ids = @recent_activities.pluck(:whodunnit).compact.uniq
+      @version_user_names = User.where(id: user_ids).pluck(:id, :name).to_h
     end
 
     # GET /office/suppliers/new

--- a/app/helpers/activity_feed_helper.rb
+++ b/app/helpers/activity_feed_helper.rb
@@ -1,0 +1,31 @@
+module ActivityFeedHelper
+  def format_activity_value(model_name, attribute_name, value)
+    if value.blank? && value != false
+      return nil
+    end
+
+    model_class = model_name.safe_constantize
+
+    if model_class && model_class.respond_to?(:defined_enums) && model_class.defined_enums.key?(attribute_name.to_s) && value.present?
+      i18n_key = model_class.model_name.i18n_key
+      return I18n.t(
+        "activerecord.attributes.#{i18n_key}.#{attribute_name}_values.#{value}",
+        default: value.to_s,
+      )
+    end
+
+    case value
+    when TrueClass
+      t("paper_trail.boolean_true")
+    when FalseClass
+      t("paper_trail.boolean_false")
+    when Date, Time, DateTime
+      l(value, format: :short)
+    # Add other specific type handling here if needed (e.g., numbers)
+    # when Numeric
+    #   number_with_precision(value, precision: 2) # Example
+    else
+      value.to_s
+    end
+  end
+end

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,6 +1,8 @@
 class Client < ApplicationRecord
   enum :client_type, regular: 0, hardware_store: 2, distributor: 1
 
+  has_paper_trail ignore: [ :created_at, :updated_at ]
+
   validates :name, presence: true
   validates :client_type, presence: true
   validates :tax_identification, presence: true, uniqueness: true

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -12,6 +12,8 @@ class Supplier < ApplicationRecord
   before_destroy :prevent_in_house_deletion, if: :in_house?
   before_update :prevent_in_house_immutable_fields, if: :in_house?
 
+  has_paper_trail ignore: [ :created_at, :updated_at, :comments ], on: %i[create update destroy]
+
   validates :name, :tax_identification, :phone, :email, presence: true
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :name, :tax_identification, uniqueness: true

--- a/app/views/common/components/_activities.html.erb
+++ b/app/views/common/components/_activities.html.erb
@@ -1,0 +1,89 @@
+<%# locals(:activities, :user_names) %>
+
+<ul role="list" class="space-y-6 mt-10">
+  <% if activities.any? %>
+    <% activities.each do |activity| %>
+
+      <% user_name = user_names[activity.whodunnit] || t('paper_trail.unknown_user') %>
+
+      <% item = activity.item || activity.reify %>
+      <% item_name = item&.name.presence || "#{activity.item_type} ##{activity.item_id}" %>
+      <% item_link = '#' %>
+      <% if item.present? %>
+        <% if activity.department.present? %>
+          <% namespace = activity.department.to_sym %>
+          <% item_link = polymorphic_path([namespace, item]) %>
+        <% else %>
+          <% item_link = polymorphic_path(item) rescue '#' %>
+        <% end %>
+      <% end %>
+
+      <% event_description = t("paper_trail.events.#{activity.event}", default: activity.event.humanize) %>
+      <% item_type_name = t(activity.item_type.underscore, scope: [:activerecord, :models], count: 1, default: activity.item_type.humanize) %>
+
+      <li class="relative flex gap-x-4">
+        <div>
+          <div class="absolute top-0 -bottom-6 left-0 flex w-6 justify-center">
+            <div class="w-px <%= 'bg-transparent' if activity == activities.last %> bg-light-gray-300"></div>
+          </div>
+          <div class="relative flex size-6 flex-none items-center justify-center bg-white">
+            <div class="size-1.5 rounded-full bg-light-gray-100 ring-1 ring-light-gray-500"></div>
+          </div>
+        </div>
+
+        <div class="flex-1 flex flex-col gap-y-2">
+          <div class="flex flex-1 items-center">
+            <p class="flex-auto py-0.5 text-xs/5 text-gray-500">
+              <span class="font-medium text-gray-900"><%= user_name %></span>
+              <%= event_description %> <%= item_type_name.downcase %>:
+              <%= link_to item_name, item_link, class: "font-medium text-gray-900" %>
+            </p>
+            <time datetime="<%= activity.created_at.iso8601 %>" class="flex-none py-0.5 text-xs/5 text-gray-500" title="<%= l(activity.created_at, format: :long) %>">
+              <%= time_ago_in_words(activity.created_at) %>
+            </time>
+          </div>
+
+          <% if activity.event == "update" && activity.changeset.present? %>
+            <div
+              data-controller="common--expand-collapse"
+              class="p-3 rounded-md border border-light-gray-300"
+            >
+              <% changes = activity.changeset %>
+              <% changes.each do |field, values| %>
+                <% field_name = t(field, scope: [:activerecord, :attributes, activity.item_type.underscore.to_sym], default: field.humanize) %>
+                <% old_value = values[0] %>
+                <% new_value = values[1] %>
+
+                <div class="mb-2 last:mb-0">
+                  <div class="text-xs/5 font-bold text-gray-700 mb-1">
+                    <%= field_name %>
+                  </div>
+
+                  <% formatted_old_value = format_activity_value(activity.item_type, field, old_value) %>
+                  <% if formatted_old_value %>
+                    <div class="mb-1 flex gap-2 text-xs/5 text-gray-700 items-center">
+                      <div><%= heroicon("minus-circle", variant: "outline", options: { class: "h-4 w-4 text-red-500" }) %></div>
+                      <div class="break-all"><%= formatted_old_value %></div>
+                    </div>
+                  <% end %>
+
+                  <% formatted_new_value = format_activity_value(activity.item_type, field, new_value) %>
+                  <% if formatted_new_value %>
+                    <div class="mb-1 flex gap-2 text-xs/5 text-gray-900 items-center">
+                      <div><%= heroicon("plus-circle", variant: "outline", options: { class: "h-4 w-4 text-green-700" }) %></div>
+                      <div class="break-all"><%= formatted_new_value %></div>
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </li>
+    <% end %>
+  <% else %>
+    <li class="text-center text-gray-500 py-4">
+      <%= t("paper_trail.no_activity") %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/office/clients/show.html.erb
+++ b/app/views/office/clients/show.html.erb
@@ -49,30 +49,10 @@
   </div>
   <div class="col-span-1 xl:col-span-2">
     <div class="border-b border-light-gray-500 bg-white py-6 mb-6">
-      <h3 class="text-base font-semibold text-gray-900">Historial de cambios</h3>
+      <h3 class="text-base font-semibold text-gray-900"><%= t("titles.recent_activities") %></h3>
     </div>
-    <ul role="list" class="-mb-8">
-      <li>
-        <div class="relative pb-8">
-          <div class="relative flex space-x-3">
-            <div>
-              <span class="flex h-8 w-8 items-center justify-center rounded-full bg-green-500 ring-8 ring-white">
-                <svg class="h-5 w-5 text-white" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                  <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" />
-                </svg>
-              </span>
-            </div>
-            <div class="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5">
-              <div>
-                <p class="text-sm text-gray-500">Cliente ingresado</p>
-              </div>
-              <div class="whitespace-nowrap text-right text-sm text-gray-500">
-                <time datetime="2020-10-04">Oct 4</time>
-              </div>
-            </div>
-          </div>
-        </div>
-      </li>
-    </ul>
+    <div class="grid gap-8 grid-cols-1 lg:grid-cols-2">
+      <%= render("common/components/activities", activities: @recent_activities, user_names: @version_user_names) %>
+    </div>
   </div>
 </div>

--- a/app/views/office/dashboard/index.html.erb
+++ b/app/views/office/dashboard/index.html.erb
@@ -1,4 +1,8 @@
-<div>
-  <h1 class="font-bold text-4xl">Tablero</h1>
-  <p>Aquí pondremos información administrativa</p>
+<div class="col-span-1 xl:col-span-2">
+  <div class="border-b border-light-gray-500 bg-white py-6 mb-6">
+    <h3 class="text-base font-semibold text-gray-900"><%= t("titles.recent_activities") %></h3>
+  </div>
+  <div class="grid gap-8 grid-cols-1 lg:grid-cols-2">
+    <%= render("common/components/activities", activities: @recent_activities, user_names: @version_user_names) %>
+  </div>
 </div>

--- a/app/views/office/suppliers/show.html.erb
+++ b/app/views/office/suppliers/show.html.erb
@@ -62,29 +62,10 @@
 
   <div class="col-span-1 xl:col-span-2">
     <div class="border-b border-light-gray-500 bg-white py-6 mb-6">
-      <h3 class="text-base font-semibold text-gray-900">Historial de cambios</h3>
+      <h3 class="text-base font-semibold text-gray-900"><%= t("titles.recent_activities") %></h3>
     </div>
-    <ul role="list" class="-mb-8">
-      <li>
-        <div class="relative pb-8">
-          <div class="relative flex space-x-3">
-            <div>
-              <span class="flex h-8 w-8 items-center justify-center rounded-full bg-green-500 ring-8 ring-white">
-                <svg class="h-5 w-5 text-white" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                  <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" />
-                </svg>
-              </span>
-            </div>
-            <div class="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5">
-              <div>
-                <p class="text-sm text-gray-500">Proveedor ingresado</p>
-              </div>
-              <div class="whitespace-nowrap text-right text-sm text-gray-500">
-                <time datetime="2020-10-04">Oct 4</time>
-              </div>
-            </div>
-          </div>
-        </div>
-      </li>
-    </ul>
+    <div class="grid gap-8 grid-cols-1 lg:grid-cols-2">
+      <%= render("common/components/activities", activities: @recent_activities, user_names: @version_user_names) %>
+    </div>
   </div>
+</div>

--- a/config/locales/comman_es.yml
+++ b/config/locales/comman_es.yml
@@ -41,6 +41,12 @@ es:
       supplier:
         one: "Proveedor"
         other: "Proveedores"
+      client:
+        one: "Cliente"
+        other: "Clientes"
+      discount:
+        one: "Descuento"
+        other: "Descuentos"
     attributes:
       formula_element:
         id: "ID"
@@ -67,6 +73,7 @@ es:
         created_at: "Ingresado"
       making_order:
         comments: "Observaciones"
+        comments_plain_text: "Observaciones"
         created_at: "Ingresado"
         id: "ID"
         making_order_formula: "Fórmula"
@@ -88,7 +95,8 @@ es:
         cover: "Portada"
         created_at: "Ingresado"
         current_stock: "Stock actual"
-        comments: "Descripción"
+        comments: "Observaciones"
+        comments_plain_text: "Observaciones"
         id: "ID"
         max_stock: "Stock máximo"
         min_stock: "Stock mínimo"
@@ -161,10 +169,12 @@ es:
         updated_at: "Actualizado"
         created_at: "Ingresado"
         comments: "Observaciones"
+        comments_plain_text: "Observaciones"
         bank_name: "Banco"
         bank_account_number: "Cuenta"
         routing_number: "CBU"
   messages:
+    ago: "hace %{time}"
     are_you_sure: "¿Estás seguro?"
     saving: "Guardando..."
     no_suppliers: "No hay proveedores"
@@ -193,6 +203,7 @@ es:
     print: "Imprimir"
     show_detail: "Ver detalle"
   titles:
+    recent_activities: "Historial de actividades"
     client:
       index: "Clientes"
       new: "Nuevo cliente"
@@ -243,3 +254,14 @@ es:
         success: "Producto actualizado"
       destroy:
         success: "Producto eliminado"
+
+  paper_trail:
+    unknown_user: "Sistema"
+    no_activity: "No hay actividad reciente."
+    blank_value: "vacio"
+    boolean_true: "Si"
+    boolean_false: "No"
+    events:
+      create: "creó"
+      update: "actualizó"
+      destroy: "eliminó"

--- a/db/migrate/20250403004953_create_versions.rb
+++ b/db/migrate/20250403004953_create_versions.rb
@@ -1,0 +1,18 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :versions do |t|
+      t.bigint   :whodunnit
+
+      t.datetime :created_at
+
+      t.bigint   :item_id,   null: false
+      t.string   :item_type, null: false
+      t.string   :event,     null: false
+      t.jsonb    :object
+      t.jsonb    :object_changes
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/migrate/20250404131631_add_department_to_versions.rb
+++ b/db/migrate/20250404131631_add_department_to_versions.rb
@@ -1,0 +1,6 @@
+class AddDepartmentToVersions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :versions, :department, :string
+    add_index :versions, :department
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:email_address) { |n| "user#{n}@example.com" }
     password { "password" }
     password_confirmation { "password" }
+    name { Faker::Name.name }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,8 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+require 'paper_trail/frameworks/rspec'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/requests/office/dashboard_spec.rb
+++ b/spec/requests/office/dashboard_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "/office", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in create(:user) }
+
+  with_versioning do
+    describe "GET index" do
+      before do
+        PaperTrail.request.whodunnit = user.id
+      end
+
+      it "renders recent activity" do
+        client = create(:client, name: "Xavier")
+        supplier = create(:supplier, name: "Company")
+        client.update!(name: "Client Name Updated")
+        supplier.update!(name: "Supplier Name Updated")
+        get office_root_url
+        expect(response).to be_successful
+        expect(response.body).to include(I18n.t("titles.recent_activities"))
+        expect(response.body).to include(user.name)
+        expect(response.body).to include("Xavier")
+        expect(response.body).to include("Client Name Updated")
+        expect(response.body).to include("Company")
+        expect(response.body).to include("Supplier Name Updated")
+        expect(response.body).to match(/#{I18n.t("paper_trail.events.create")}/i)
+        expect(response.body).to match(/#{I18n.t("paper_trail.events.update")}/i)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Architecture

Audit logs are written to a dedicated `AuditLog` model. Only models that explicitly declare `auditable` will generate audit logs. Associated models can contribute changes to their parent model’s audit log using `audit_changes_raw`.

All internal behavior is encapsulated using `after_commit` hooks for `create`, `update`, and `destroy`, ensuring audit logs are only written after a successful transaction.

## DSL and Usage

### Enabling auditing in a model

```ruby
class Product < ApplicationRecord
  auditable only: [:name, :price, :supplier_products]
end
```

You may also use `except:` instead of `only:`:

```ruby
class Client < ApplicationRecord
  auditable except: [:created_at, :updated_at]
end
```

### Declaring audit-relevant fields in associated models

```ruby
class SupplierProduct < ApplicationRecord
  auditable_attributes only: [:price, :code]

  def audit_name
    supplier&.name
  end
end
```

- `auditable_attributes`: defines which attributes are tracked if this model is included in another model's audit
- `audit_name`: returns a user-friendly label for use in audit logs (used especially for created/destroyed records)

## Key Concepts

- Audit logs are only written in `after_commit`, ensuring rollback safety
- A single audit log entry is created per `save`, combining changes from the model and its relevant associations
- Changes are stored in a flat format using dot-notation keys
- Each model that includes `Auditable` defines one public method: `audit_changes_raw`
- All other audit-related instance methods are private

## Behavior

1. The auditing process is triggered when an auditable model is saved.
2. In `after_commit`, the model:
   - Gathers its own changes from `previous_changes`
   - Iterates through any tracked associations and calls `audit_changes_raw` on them
   - Prepends the association name and record ID to each change key
3. If there are any changes (either in the model or its associations), a single `AuditLog` is created.

## Example AuditLog Entry

```json
{
  "action": "update",
  "auditable_type": "Product",
  "auditable_id": 42,
  "user_id": 1,
  "transaction_id": "d51f1d93-e7fa-41f3-a0f6-2f5de1f179d5",
  "created_at": "2025-05-07T13:12:54Z",
  "changes": {
    "price": [15.0, 20.0],
    "supplier_products.123._destroyed": ["SupplierOne", null],
    "supplier_products.124.price": [10.0, 12.0],
    "supplier_products.999._created": [null, "SupplierTwo"]
  },
  "changed_attributes": [
    "price",
    "supplier_products._destroyed",
    "supplier_products.price",
    "supplier_products._created"
  ]
}
```

## Database Schema

```ruby
create_table :audit_logs do |t|
  t.string  :auditable_type, null: false
  t.bigint  :auditable_id, null: false
  t.string  :action, null: false
  t.jsonb   :changes, default: {}
  t.string  :changed_attributes, array: true, default: []
  t.references :user, foreign_key: true
  t.string  :transaction_id
  t.datetime :created_at, null: false
end

add_index :audit_logs, [:auditable_type, :auditable_id]
add_index :audit_logs, :changed_attributes, using: :gin
```

Note: `updated_at` is excluded since audit logs are immutable.

## Advantages

- Consistent, rollback-safe audit logging using `after_commit`
- Clean public API with private encapsulation of helpers
- Declarative configuration of tracked fields and associations
- Flat, dot-notation key structure optimized for rendering and querying
- Fully I18n-friendly — no UI strings stored in the log
