### PR TITLE
Clients audit logging

### DIFF
--- a/app/controllers/office/clients_controller.rb
+++ b/app/controllers/office/clients_controller.rb
@@ -11,6 +11,7 @@ module Office
 
     # GET /clients/1
     def show
+      @audit_logs = @client.audit_logs.recent.includes(:user)
     end
 
     # GET /clients/1/edit

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -1,5 +1,7 @@
 class Client < ApplicationRecord
-  include HasRichComments
+  include HasRichComments, Auditable
+
+  auditable
 
   enum :client_type, regular: 0, hardware_store: 2, distributor: 1
   enum :tax_type, final_consumer: 0, general_regime: 1, simplified_regime: 2

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,6 +1,17 @@
 class Product < ApplicationRecord
   include Productables, HasRichComments, Auditable
 
+  auditable only: %i[
+    name
+    current_stock
+    max_stock
+    min_stock
+    price
+    comments_plain_text
+    supplied_by
+    supplier
+  ]
+
   has_one_attached :cover do |attachable|
     attachable.variant :hero, resize_to_fill: [ 400, 400 ]
     attachable.variant :thumb, resize_to_fill: [ 100, 100 ]
@@ -24,17 +35,6 @@ class Product < ApplicationRecord
   validate :prevent_removal_of_in_house_supplier_product_for_manufactured
 
   accepts_nested_attributes_for :supplied_by, allow_destroy: true, reject_if: :all_blank
-
-  auditable only: %i[
-    name
-    current_stock
-    max_stock
-    min_stock
-    price
-    comments_plain_text
-    supplied_by
-    supplier
-  ]
 
   def self.ransackable_attributes(auth_object = nil)
     %w[id name current_stock price created_at productable_type stock_level]

--- a/app/tasks/maintenance/create_audit_logs_for_clients_task.rb
+++ b/app/tasks/maintenance/create_audit_logs_for_clients_task.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class CreateAuditLogsForClientsTask < MaintenanceTasks::Task
+    def collection
+      Client.left_outer_joins(:audit_logs).where(audit_logs: { id: nil })
+        .or(Client.left_outer_joins(:audit_logs).where.not(audit_logs: { action: "create" }))
+        .distinct
+    end
+
+    def process(client)
+      return if client.audit_logs.exists?(action: "create")
+
+      AuditLog.create!(
+        action: "create",
+        auditable: client,
+        audited_changes: { "_created" => [ nil, client.name ] },
+        audited_fields: [ "_created" ],
+        created_at: client.created_at,
+        transaction_id: "created by maintenance task: #{self.class.name}",
+        user_id: nil
+      )
+    end
+
+    def count
+      self.collection.count
+    end
+  end
+end

--- a/app/tasks/maintenance/create_audit_logs_for_clients_task.rb
+++ b/app/tasks/maintenance/create_audit_logs_for_clients_task.rb
@@ -3,8 +3,9 @@
 module Maintenance
   class CreateAuditLogsForClientsTask < MaintenanceTasks::Task
     def collection
-      Client.left_outer_joins(:audit_logs).where(audit_logs: { id: nil })
-        .or(Client.left_outer_joins(:audit_logs).where.not(audit_logs: { action: "create" }))
+      Client.left_outer_joins(:audit_logs)
+        .where(audit_logs: { id: nil })
+        .or(Client.where.not(audit_logs: { action: "create" }))
         .distinct
     end
 

--- a/app/views/office/clients/show.html.erb
+++ b/app/views/office/clients/show.html.erb
@@ -61,30 +61,10 @@
   </div>
   <div class="col-span-1 xl:col-span-2">
     <div class="border-b border-light-gray-500 bg-white py-6 mb-6">
-      <h3 class="text-base font-semibold text-gray-900">Historial de cambios</h3>
+      <h3 class="text-base font-semibold text-gray-900"><%= t("titles.recent_activities") %></h3>
     </div>
-    <ul role="list" class="-mb-8">
-      <li>
-        <div class="relative pb-8">
-          <div class="relative flex space-x-3">
-            <div>
-              <span class="flex h-8 w-8 items-center justify-center rounded-full bg-green-500 ring-8 ring-white">
-                <svg class="h-5 w-5 text-white" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                  <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" />
-                </svg>
-              </span>
-            </div>
-            <div class="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5">
-              <div>
-                <p class="text-sm text-gray-500">Cliente ingresado</p>
-              </div>
-              <div class="whitespace-nowrap text-right text-sm text-gray-500">
-                <time datetime="2020-10-04">Oct 4</time>
-              </div>
-            </div>
-          </div>
-        </div>
-      </li>
-    </ul>
+    <div class="grid gap-8 grid-cols-1 lg:grid-cols-2">
+      <%= render("common/components/activities", audit_logs: @audit_logs) %>
+    </div>
   </div>
 </div>

--- a/spec/tasks/maintenance/create_audit_logs_for_clients_task_spec.rb
+++ b/spec/tasks/maintenance/create_audit_logs_for_clients_task_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe CreateAuditLogsForClientsTask do
+    describe "#collection" do
+      let!(:record_created_at) { DateTime.parse("2023-10-01 06:31:00") }
+      let!(:client1) do
+        Auditable.without_auditing do
+          create(:client,
+            name: "Test Client",
+            client_type: :regular,
+            tax_identification: "123456",
+            tax_type: :final_consumer,
+            created_at: record_created_at,
+          )
+        end
+      end
+
+      let(:client2) do
+        Auditable.without_auditing do
+          create(:client,
+            name: "Another Client",
+            client_type: :distributor,
+            tax_identification: "654321",
+            tax_type: :general_regime,
+            created_at: record_created_at,
+          )
+        end
+      end
+
+      it "collects clients without audit logs" do
+        client2.assign_attributes(name: "Updated Client")
+        Auditable.with_auditing { client2.save! }
+        client3 = Auditable.with_auditing do
+          create(:client,
+            name: "Last Client",
+            client_type: :hardware_store,
+            tax_identification: "999999",
+            tax_type: :simplified_regime,
+            created_at: record_created_at,
+          )
+        end
+        expect(described_class.collection).not_to include(client3)
+        expect(described_class.collection).to contain_exactly(client1, client2)
+      end
+    end
+
+    describe "#process" do
+      let!(:record_created_at) { DateTime.parse("2023-10-01 06:31:00") }
+      let!(:client1) do
+        Auditable.without_auditing do
+          create(:client,
+            name: "Test Client",
+            client_type: :regular,
+            tax_identification: "123456",
+            tax_type: :final_consumer,
+            created_at: record_created_at,
+          )
+        end
+      end
+
+      it "creates an audit log for the client1" do
+        allow(Time).to receive(:current).and_return(record_created_at)
+        expect { described_class.process(client1) }.to change(AuditLog, :count).by(1)
+        expect(AuditLog.last).to have_attributes(
+          action: "create",
+          auditable: client1,
+          audited_changes: { "_created" => [ nil, client1.name ] },
+          audited_fields: [ "_created" ],
+          created_at: record_created_at,
+          transaction_id: "created by maintenance task: Maintenance::CreateAuditLogsForClientsTask",
+          user_id: nil,
+        )
+      end
+
+      it "sets created_at to the client's created_at" do
+        allow(Time).to receive(:current).and_return(record_created_at)
+        described_class.process(client1)
+        expect(AuditLog.last.created_at).to eq(record_created_at)
+      end
+
+      it "does not create duplicate audit logs" do
+        described_class.process(client1)
+        described_class.process(client1)
+        expect(client1.audit_logs.where(action: "create").size).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This pull request introduces auditing functionality to the `Client` model, refactors the `Auditable` concern for better configuration management, and includes a new maintenance task for creating audit logs for clients. It updates the UI to display recent activities for clients.

## Deployment Notes

In order to create audit logs for existing client records run the following command:
```ruby
bundle exec maintenance_tasks perform Maintenance::CreateAuditLogsForClientsTask
```
