### PR TITLE
Suppliers audit logging

### DIFF
--- a/app/controllers/office/suppliers_controller.rb
+++ b/app/controllers/office/suppliers_controller.rb
@@ -13,6 +13,7 @@ module Office
 
     # GET /office/suppliers/1 or /office/suppliers/1.json
     def show
+      @audit_logs = @supplier.audit_logs.recent.includes(:user)
     end
 
     # GET /office/suppliers/new

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -5,9 +5,9 @@ class Supplier < ApplicationRecord
 
   enum :tax_type, general_regime: 0, simplified_regime: 1, exempt: 2
 
-  has_many :products_supplied, class_name: "SupplierProduct", dependent: :destroy
-  has_many :purchased_products, through: :products_supplied
-  has_many :active_products, class_name: "Product", foreign_key: "supplier_id", dependent: :nullify
+  has_many :supplier_products, dependent: :destroy
+  has_many :supplied_products, through: :supplier_products
+  has_many :main_products, class_name: "Product", foreign_key: "supplier_id", dependent: :nullify
 
   scope :in_house, -> { find_by!(in_house: true) }
 

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -1,6 +1,8 @@
 class Supplier < ApplicationRecord
   include HasRichComments, Auditable
 
+  auditable
+
   enum :tax_type, general_regime: 0, simplified_regime: 1, exempt: 2
 
   has_many :products_supplied, class_name: "SupplierProduct", dependent: :destroy

--- a/app/tasks/maintenance/create_audit_logs_for_suppliers_task.rb
+++ b/app/tasks/maintenance/create_audit_logs_for_suppliers_task.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Maintenance
+  class CreateAuditLogsForSuppliersTask < MaintenanceTasks::Task
+    def collection
+      Supplier.left_outer_joins(:audit_logs)
+        .where(audit_logs: { id: nil })
+        .or(Supplier.where.not(audit_logs: { action: "create" }))
+        .distinct
+    end
+
+    def process(supplier)
+      return if supplier.audit_logs.exists?(action: "create")
+
+      AuditLog.create!(
+        action: "create",
+        auditable: supplier,
+        audited_changes: { "_created" => [ nil, supplier.name ] },
+        audited_fields: [ "_created" ],
+        created_at: supplier.created_at,
+        transaction_id: "created by maintenance task: #{self.class.name}",
+        user_id: nil
+      )
+    end
+
+    def count
+      self.collection.count
+    end
+  end
+end

--- a/app/views/office/suppliers/show.html.erb
+++ b/app/views/office/suppliers/show.html.erb
@@ -60,31 +60,12 @@
     ) %>
   </div>
 
-  <div class="col-span-1 xl:col-span-2">
+  <div class="col-span-1 xl:col-span-2 2xl:col-span-3">
     <div class="border-b border-light-gray-500 bg-white py-6 mb-6">
-      <h3 class="text-base font-semibold text-gray-900">Historial de cambios</h3>
+      <h3 class="text-base font-semibold text-gray-900"><%= t("titles.recent_activities") %></h3>
     </div>
-    <ul role="list" class="-mb-8">
-      <li>
-        <div class="relative pb-8">
-          <div class="relative flex space-x-3">
-            <div>
-              <span class="flex h-8 w-8 items-center justify-center rounded-full bg-green-500 ring-8 ring-white">
-                <svg class="h-5 w-5 text-white" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
-                  <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" />
-                </svg>
-              </span>
-            </div>
-            <div class="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5">
-              <div>
-                <p class="text-sm text-gray-500">Proveedor ingresado</p>
-              </div>
-              <div class="whitespace-nowrap text-right text-sm text-gray-500">
-                <time datetime="2020-10-04">Oct 4</time>
-              </div>
-            </div>
-          </div>
-        </div>
-      </li>
-    </ul>
+    <div class="grid gap-8 grid-cols-1 lg:grid-cols-2">
+      <%= render("common/components/activities", audit_logs: @audit_logs) %>
+    </div>
   </div>
+</div>

--- a/spec/models/concerns/auditable_spec.rb
+++ b/spec/models/concerns/auditable_spec.rb
@@ -189,12 +189,14 @@ RSpec.describe "Auditable", type: :model do
     end
 
     it "resumes audit logging after the block" do
+      audit_logs_count = AuditLog.count
+
       Auditable.without_auditing do
         product.update!(name: "Suppressed Change")
       end
 
       # Ensure no audit log was created for the suppressed change
-      expect(AuditLog.count).to eq(1)
+      expect(AuditLog.count).to eq(audit_logs_count)
 
       # Make a change outside the suppress block
       expect {
@@ -209,6 +211,7 @@ RSpec.describe "Auditable", type: :model do
 
     it "restores the original suppression state even if an error occurs" do
       ActiveSupport::IsolatedExecutionState[:auditing_suppressed] = false
+      audit_logs_count = AuditLog.count
 
       expect {
         Auditable.without_auditing do
@@ -217,7 +220,7 @@ RSpec.describe "Auditable", type: :model do
         end
       }.to raise_error("Something went wrong")
 
-      expect(AuditLog.count).to eq(1)
+      expect(AuditLog.count).to eq(audit_logs_count)
 
       expect(ActiveSupport::IsolatedExecutionState[:auditing_suppressed]).to eq(false)
 

--- a/spec/tasks/maintenance/create_audit_logs_for_suppliers_task_spec.rb
+++ b/spec/tasks/maintenance/create_audit_logs_for_suppliers_task_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Maintenance
+  RSpec.describe CreateAuditLogsForSuppliersTask do
+    describe "#collection" do
+      let!(:record_created_at) { DateTime.parse("2023-10-01 06:31:00") }
+      let!(:supplier1) do
+        Auditable.without_auditing do
+          create(:supplier,
+            name: "Test Supplier",
+            created_at: record_created_at,
+          )
+        end
+      end
+
+      let(:supplier2) do
+        Auditable.without_auditing do
+          create(:supplier,
+            name: "Another Supplier",
+            created_at: record_created_at,
+          )
+        end
+      end
+
+      it "collects suppliers without audit logs" do
+        supplier2.assign_attributes(name: "Updated Supplier")
+        Auditable.with_auditing { supplier2.save! }
+        supplier3 = Auditable.with_auditing do
+          create(:supplier,
+            name: "Last Supplier",
+            created_at: record_created_at,
+          )
+        end
+        expect(described_class.collection).not_to include(supplier3)
+        expect(described_class.collection).to contain_exactly(supplier1, supplier2)
+      end
+    end
+
+    describe "#process" do
+      let!(:record_created_at) { DateTime.parse("2023-10-01 06:31:00") }
+      let!(:supplier1) do
+        Auditable.without_auditing do
+          create(:supplier,
+            name: "Test Supplier",
+            created_at: record_created_at,
+          )
+        end
+      end
+
+      it "creates an audit log for the supplier1" do
+        allow(Time).to receive(:current).and_return(record_created_at)
+        expect { described_class.process(supplier1) }.to change(AuditLog, :count).by(1)
+        expect(AuditLog.last).to have_attributes(
+          action: "create",
+          auditable: supplier1,
+          audited_changes: { "_created" => [ nil, supplier1.name ] },
+          audited_fields: [ "_created" ],
+          created_at: record_created_at,
+          transaction_id: "created by maintenance task: Maintenance::CreateAuditLogsForSuppliersTask",
+          user_id: nil,
+        )
+      end
+
+      it "sets created_at to the supplier's created_at" do
+        allow(Time).to receive(:current).and_return(record_created_at)
+        described_class.process(supplier1)
+        expect(AuditLog.last.created_at).to eq(record_created_at)
+      end
+
+      it "does not create duplicate audit logs" do
+        described_class.process(supplier1)
+        described_class.process(supplier1)
+        expect(supplier1.audit_logs.where(action: "create").size).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This pull request introduces enhancements to audit logging for suppliers, refactors associated models and views, and adds a maintenance task to backfill missing audit logs.

## Deployment Notes

In order to create audit logs for existing client records run the following command:
```ruby
bundle exec maintenance_tasks perform Maintenance::CreateAuditLogsForSuppliersTask
```
