### PR TITLE
Client index UI adjustments

### DIFF
--- a/app/views/office/clients/index.html.erb
+++ b/app/views/office/clients/index.html.erb
@@ -73,15 +73,15 @@
             <tbody class="divide-y divide-light-gray">
               <% @clients.each do |client| %>
                 <tr id="<%= dom_id client %>">
-                  <td class="whitespace-nowrap px-3 py-3 text-center text-sm text-gray-900">
+                  <td class="px-3 py-3 text-center text-sm text-gray-900">
                     <%= link_to client.id, office_client_path(client), data: { turbo_frame: "_top" } %>
                   </td>
-                  <td class="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium text-gray-900">
+                  <td class="py-3 pl-4 pr-3 text-sm font-medium text-gray-900">
                     <%= link_to office_client_path(client), data: { turbo_frame: "_top" } do %>
                       <span class="sr-only">Ver client </span><span><%= client.name %></span>
                     <% end %>
                   </td>
-                  <td class="hidden md:table-cell whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-500">
+                  <td class="hidden md:table-cell px-2 md:px-4 py-3 text-sm text-gray-500">
                     <% if client.maps_url.present? %>
                       <%= link_to(safe_url(client.maps_url), class: "flex items-center gap-2", target: "_blank") do %>
                         <%= heroicon("map-pin", options: { class: "h-4 w-4 shrink-0 transition text-gray-300 hover:text-gray-700" }) +
@@ -91,16 +91,16 @@
                       <%= client.full_address %>
                     <% end %>
                   </td>
-                  <td class="table-cell whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-500">
+                  <td class="table-cell px-2 md:px-4 py-3 text-sm text-gray-500">
                     <%= client.tax_identification %>
                   </td>
-                  <td class="hidden lg:table-cell whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-500">
+                  <td class="hidden lg:table-cell px-2 md:px-4 py-3 text-sm text-gray-500">
                     <%= t(client.tax_type, scope: [:activerecord, :attributes, :client, :tax_type_values]) %>
                   </td>
-                  <td class="hidden lg:table-cell whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-500">
+                  <td class="hidden lg:table-cell px-2 md:px-4 py-3 text-sm text-gray-500">
                     <%= t(client.client_type, scope: [:activerecord, :attributes, :client, :client_type_values]) %>
                   </td>
-                  <td class="hidden 2xl:table-cell whitespace-nowrap px-2 md:px-4 py-3 text-sm text-gray-500">
+                  <td class="hidden 2xl:table-cell px-2 md:px-4 py-3 text-sm text-gray-500">
                     <%= client.seller_name %>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary

Allow table cells to wrap text. An alternative approach would be to truncate the full address to minimize horizontal space usage.

<!-- ## Deployment Notes -->

<!-- Provide any specific deployment notes or steps that need to be taken post-merge. -->
