### PR TITLE
Sales order fixed prices and discounts

### DIFF
--- a/app/controllers/sales/orders_controller.rb
+++ b/app/controllers/sales/orders_controller.rb
@@ -113,17 +113,13 @@ module Sales
 
     def order_params
       params.require(:sales_order).permit(
-        :cash_discount_percentage,
-        :client_discount_percentage,
         :client_id,
         :comments,
-        :id,
         items_attributes: [
           :_destroy,
           :id,
           :product_id,
           :quantity,
-          :unit_price,
         ]
       )
     end

--- a/app/helpers/activity_feed_helper.rb
+++ b/app/helpers/activity_feed_helper.rb
@@ -48,7 +48,10 @@ module ActivityFeedHelper
   end
 
   def link_to_auditable(auditable, options = {})
-    if path = polymorphic_path([ Current.department, auditable ]) rescue nil
+    path = polymorphic_path([ Current.department, auditable ]) rescue nil
+    path ||= polymorphic_path(auditable) rescue nil
+
+    if path
       link_to(
         auditable.audit_name,
         path,

--- a/app/models/sales/order.rb
+++ b/app/models/sales/order.rb
@@ -172,7 +172,11 @@ module Sales
     end
 
     def can_cancel?
-      persisted? && (quote? || confirmed?)
+      !any_item_delivered? && persisted? && (quote? || confirmed?)
+    end
+
+    def any_item_delivered?
+      items.any? { |item| item.delivered? }
     end
 
     def cancel!

--- a/app/views/common/components/_activities.html.erb
+++ b/app/views/common/components/_activities.html.erb
@@ -27,10 +27,7 @@
           </div>
 
           <% if audit_log.action == "update" && audit_log.audited_changes.keys.any? %>
-            <div
-              data-controller="common--expand-collapse"
-              class="p-3 rounded-md border border-light-gray-300"
-            >
+            <div class="p-3 rounded-md border border-light-gray-300">
               <% audit_log.audited_changes.each do |field, values| %>
                 <div class="mb-2 last:mb-0">
                   <div class="text-xs/5 font-bold text-gray-700 mb-1">

--- a/app/views/sales/orders/_item_fields.html.erb
+++ b/app/views/sales/orders/_item_fields.html.erb
@@ -25,10 +25,9 @@
           :unit_price,
           value: item.effective_unit_price,
           placeholder: true,
-          min: 1,
-          step: 1,
-          disabled: marked_for_destruction,
-          class: "col-start-1 row-start-1 block w-full rounded-md border-0 pl-5 py-1.5 text-xs/6 text-gray-900 shadow-sm outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-300 focus:outline-1 focus:-outline-offset-1 focus:outline-blue-300 sm:leading-6 #{ 'outline-red' if item.errors.any? }",
+          disabled: true,
+          readonly: true,
+          class: "col-start-1 row-start-1 block w-full rounded-md border-0 pl-5 py-1.5 text-xs/6 text-gray-900 shadow-sm placeholder:text-gray-300 disabled:cursor-not-allowed disabled:bg-light-gray-100 disabled:text-gray-500 disabled:outline-gray-300 focus:outline-1 focus:-outline-offset-1 focus:outline-blue-300 sm:leading-6 #{ 'outline-red' if item.errors.any? }",
           data: {
             "sales--orders--form-product-target": "price",
             "action": "sales--orders--form#updateTotals",

--- a/app/views/sales/orders/_order_fields.html.erb
+++ b/app/views/sales/orders/_order_fields.html.erb
@@ -16,7 +16,9 @@
       <div class="mt-2 grid grid-cols-1">
         <%= form.number_field :cash_discount_percentage,
           placeholder: true,
-          class: "col-start-1 row-start-1 block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-300 focus:outline-1 focus:-outline-offset-1 focus:outline-blue-300 sm:text-sm sm:leading-6",
+          disabled: true,
+          readonly: true,
+          class: "col-start-1 row-start-1 block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-300 disabled:cursor-not-allowed disabled:bg-light-gray-100 disabled:text-gray-500 disabled:outline-gray-300 focus:outline-1 focus:-outline-offset-1 focus:outline-blue-300 sm:text-sm sm:leading-6",
           data: { "action": "sales--orders--form#updateTotals" }
         %>
         <span class="pointer-events-none col-start-1 row-start-1 mr-3 size-5 self-center justify-self-end text-gray-100 sm:size-5 font-light">%</span>
@@ -28,7 +30,9 @@
       <div class="mt-2 grid grid-cols-1">
         <%= form.number_field :client_discount_percentage,
           placeholder: true,
-          class: "col-start-1 row-start-1 block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-300 focus:outline-1 focus:-outline-offset-1 focus:outline-blue-300 sm:text-sm sm:leading-6",
+          disabled: true,
+          readonly: true,
+          class: "col-start-1 row-start-1 block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-300 disabled:cursor-not-allowed disabled:bg-light-gray-100 disabled:text-gray-500 disabled:outline-gray-300  focus:outline-1 focus:-outline-offset-1 focus:outline-blue-300 sm:text-sm sm:leading-6",
           data: { "action": "sales--orders--form#updateTotals" }
         %>
         <span class="pointer-events-none col-start-1 row-start-1 mr-3 size-5 self-center justify-self-end text-gray-100 sm:size-5 font-light">%</span>

--- a/spec/requests/sales/orders_spec.rb
+++ b/spec/requests/sales/orders_spec.rb
@@ -58,17 +58,23 @@ RSpec.describe "/orders", type: :request do
     let(:sales_order) { create(:sales_order, products_count: 1) }
     let(:valid_attributes) do
       {
-        cash_discount_percentage: 50,
-        client_discount_percentage: 60,
         comments: "Updated order",
+        items_attributes: [
+          {
+            id: sales_order.items.first.id,
+            product_id: sales_order.items.first.product_id,
+            quantity: 3,
+            _destroy: false,
+          },
+        ],
       }
     end
 
     it "updates the Order" do
       patch sales_order_url(sales_order), params: { sales_order: valid_attributes }
       sales_order.reload
-      expect(sales_order.cash_discount_percentage).to eq(50)
-      expect(sales_order.client_discount_percentage).to eq(60)
+      expect(sales_order.comments_plain_text).to eq("Updated order")
+      expect(sales_order.items.first.quantity).to eq(3)
       expect(response).to redirect_to(edit_sales_order_url(sales_order))
     end
 


### PR DESCRIPTION
## Summary

This pull request includes changes to improve the handling of sales orders.
Disables discounts and price fields for editing.
Prevents canceling an order that includes one or more already delivered products.
